### PR TITLE
fix(xml-transpiler): Log unknown namespaces as verbose instead of warning

### DIFF
--- a/src/detectors/transpilers/xml/Parser.ts
+++ b/src/detectors/transpilers/xml/Parser.ts
@@ -459,7 +459,7 @@ export default class Parser {
 					// in the control aggregation
 					this.#generator.writeControl(customData);
 				} else {
-					log.warn(`Ignoring unknown namespaced attribute ${attr.localNamespace}:${attr.name} ` +
+					log.verbose(`Ignoring unknown namespaced attribute ${attr.localNamespace}:${attr.name} ` +
 					`for ${moduleName} in resource ${this.#resourceName}`);
 				}
 			} else {


### PR DESCRIPTION
Ignoring them seems safe, so no warning should be produced. There's
typically also nothing a developer can do to resolve the warning.