### PR TITLE
feat(cli)!: In case of errors, exit with code 1

### DIFF
--- a/src/cli/base.ts
+++ b/src/cli/base.ts
@@ -141,6 +141,11 @@ async function handleLint(argv: ArgumentsCamelCase<LinterArg>) {
 	if (profile) {
 		await profile.stop();
 	}
+
+	if (res.some((file) => !!file.errorCount)) {
+		// At least one error is reported. Exit with non-zero exit code.
+		process.exit(1);
+	}
 }
 
 export default function base(cli: Argv) {
@@ -191,7 +196,7 @@ export default function base(cli: Argv) {
 				process.stderr.write("\n");
 				process.stderr.write(chalk.dim(`See 'ui5lint --help'`) + "\n");
 			}
-			process.exit(1);
+			process.exit(2);
 		});
 
 	cli.command(lintCommand);

--- a/test/lib/cli/base.integration.ts
+++ b/test/lib/cli/base.integration.ts
@@ -13,6 +13,7 @@ const test = anyTest as TestFn<{
 	consoleLogStub: SinonStub;
 	processCwdStub: SinonStub;
 	processStdoutWriteStub: SinonStub;
+	processExitStub: SinonStub;
 	cli: Argv;
 }>;
 
@@ -20,6 +21,7 @@ test.beforeEach((t) => {
 	t.context.consoleLogStub = sinon.stub(console, "log");
 	t.context.processCwdStub = sinon.stub(process, "cwd").returns(sampleProjectPath);
 	t.context.processStdoutWriteStub = sinon.stub(process.stdout, "write").returns(true);
+	t.context.processExitStub = sinon.stub(process, "exit");
 	t.context.cli = yargs();
 	cliBase(t.context.cli);
 });
@@ -30,15 +32,17 @@ test.afterEach.always(() => {
 
 // Test if standard output is parsable JSON
 test.serial("ui5lint --format json", async (t) => {
-	const {cli} = t.context;
+	const {cli, consoleLogStub, processCwdStub, processStdoutWriteStub, processExitStub} = t.context;
 
 	await cli.parseAsync(["--format", "json"]);
 
-	t.is(t.context.consoleLogStub.callCount, 0, "console.log should not be used");
-	t.true(t.context.processCwdStub.callCount > 0, "process.cwd was called");
-	t.is(t.context.processStdoutWriteStub.callCount, 1, "process.stdout.write is only used once");
+	t.is(consoleLogStub.callCount, 0, "console.log should not be used");
+	t.true(processCwdStub.callCount > 0, "process.cwd was called");
+	t.is(processStdoutWriteStub.callCount, 1, "process.stdout.write is only used once");
+	t.is(processExitStub.callCount, 1, "process.exit got called once");
+	t.is(processExitStub.firstCall.firstArg, 1, "process.exit got called with exit code 1");
 
-	const resultProcessStdout = t.context.processStdoutWriteStub.firstCall.firstArg;
+	const resultProcessStdout = processStdoutWriteStub.firstCall.firstArg;
 	let parsedJson: LintResult[];
 
 	t.notThrows(() => parsedJson = JSON.parse(resultProcessStdout), "Output of process.stdout.write is JSON-formatted");


### PR DESCRIPTION
This change alignes UI5 linter with ESLint (see [1]):
* No errors, maybe warnings: **Use exit code 0**
* At least one error: **Use exit code 1**
* Unexpected error (typically caused by an exception): **Use exit code 2**

**BREAKING CHANGE:** Depending on how UI5 linter is being used, this change
might change the behavior of that particular scenario. For example a
build script might abort further processing, if any linting errors
are detected.

To ignore exit code 1, for example in a bash script, you may use a
construct like this:
```sh
ui5lint && RC=$? || RC=$?
if [[ "$RC" = 2 ]]; then
    exit 1
fi
```

JIRA: CPOUI5FOUNDATION-823

[1]: https://eslint.org/docs/latest/use/command-line-interface#exit-codes