### PR TITLE
build: Do not use the linting-tsconfig for emitting files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "npm run cleanup && tsc -p tsconfig.build.json",
-		"build-test": "npm run cleanup && tsc -p .",
+		"build-test": "tsc --noEmit -p .",
 		"build-watch": "npm run cleanup && tsc -w -p tsconfig.build.json",
 		"check-licenses": "licensee --errors-only",
 		"cleanup": "rimraf lib coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
 	// This is our configuration for development and linting,
 	// compared to "tsconfig.build.json" it also includes tests
 	// and other TypeScript sources in the project
+	// For this reason however, it should not be used to emit JavaScript (except for linting purposes),
+	// since the output directory would then contain "src" and "test" directories instead of just the content of "src"
 	"extends": "./tsconfig.base.json",
 	"include": [
 		"src/**/*",


### PR DESCRIPTION
Only use "tsconfig.build.json" for building and emitting. Use
"tsconfig.json" for checking for compiler errors and for integrating
with typescript-eslint.

The directory structure emitted when using "tsconfig.json" is different
from the regular build in the sense that it contains an additional "src"
directory level.

Configuring "noEmit: true" in the tsconfig file causes issues for the
typescript-eslint integration. Therefore the flag is only set in the npm
script.