### PR TITLE
ci: Skip test-build in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,5 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Perform build
-      run: npm run build-test
-
     - name: Run unit tests
       run: npm run unit


### PR DESCRIPTION
The "test-build" script compiles the code to check for TypeScript
compilation errors. This is not specific to Node.js / OS and can
therefore be skipped in the matrix. It is also no prerequisite for
running the unit tests, as ava compiles them on-the-fly.
The "test-build" script is still part of the ci.yml workflow.