### PR TITLE
build(lockfile): Switch lockfile to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,27 +97,27 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
-			"integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
-			"integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+			"integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.2",
-				"@babel/generator": "^7.24.1",
+				"@babel/generator": "^7.24.4",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.24.1",
-				"@babel/parser": "^7.24.1",
+				"@babel/helpers": "^7.24.4",
+				"@babel/parser": "^7.24.4",
 				"@babel/template": "^7.24.0",
 				"@babel/traverse": "^7.24.1",
 				"@babel/types": "^7.24.0",
@@ -145,9 +145,9 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
-			"integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+			"integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.24.0",
@@ -309,9 +309,9 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
-			"integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+			"integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.24.0",
@@ -388,9 +388,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-			"integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+			"integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1263,9 +1263,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
 		"node_modules/@isaacs/cliui": {
@@ -1524,15 +1524,15 @@
 			}
 		},
 		"node_modules/@npmcli/agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.1.tgz",
-			"integrity": "sha512-H4FrOVtNyWC8MUwL3UfjOsAihHvT1Pe8POj3JvjXhSTJipsZMtgUALCT4mGyYZNxymkUfOw3PUj6dE4QPp6osQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
 			"dependencies": {
 				"agent-base": "^7.1.0",
 				"http-proxy-agent": "^7.0.0",
 				"https-proxy-agent": "^7.0.1",
 				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.1"
+				"socks-proxy-agent": "^8.0.3"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
@@ -1853,13 +1853,13 @@
 			}
 		},
 		"node_modules/@npmcli/config": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.2.0.tgz",
-			"integrity": "sha512-YoEYZFg0hRSRP/Chmq+J4FvULFvji6SORUYWQc10FiJ+ReAnViXcDCENg6kM6dID04bAoKNUygrby798+gYBbQ==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.2.1.tgz",
+			"integrity": "sha512-G4PknBr51bwCuY63wXSO8OakSoyHk11JYhxAZCayCAosJruX86lAstCfbr/2Fr+g6OqVz6PPfOVZ98bcoc+eQA==",
 			"dependencies": {
 				"@npmcli/map-workspaces": "^3.0.2",
 				"ci-info": "^4.0.0",
-				"ini": "^4.1.0",
+				"ini": "^4.1.2",
 				"nopt": "^7.0.0",
 				"proc-log": "^3.0.0",
 				"read-package-json-fast": "^3.0.2",
@@ -2371,6 +2371,14 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@npmcli/redact": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-1.1.0.tgz",
+			"integrity": "sha512-PfnWuOkQgu7gCbnSsAisaX7hKOdZ4wSAhAzH3/ph5dSGau52kCRrMMGbiSQLwyTZpgldkZ49b0brkOr1AzGBHQ==",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
 		"node_modules/@npmcli/run-script": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
@@ -2423,11 +2431,11 @@
 			}
 		},
 		"node_modules/@sigstore/bundle": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.2.0.tgz",
-			"integrity": "sha512-5VI58qgNs76RDrwXNhpmyN/jKpq9evV/7f1XrcqcAfvxDl5SeVY/I5Rmfe96ULAV7/FK5dge9RBKGBJPhL1WsQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
+			"integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.0"
+				"@sigstore/protobuf-specs": "^0.3.1"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
@@ -2442,21 +2450,21 @@
 			}
 		},
 		"node_modules/@sigstore/protobuf-specs": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.0.tgz",
-			"integrity": "sha512-zxiQ66JFOjVvP9hbhGj/F/qNdsZfkGb/dVXSanNRNuAzMlr4MC95voPUBX8//ZNnmv3uSYzdfR/JSkrgvZTGxA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.1.tgz",
+			"integrity": "sha512-aIL8Z9NsMr3C64jyQzE0XlkEyBLpgEJJFDHLVVStkFV5Q3Il/r/YtY6NJWKQ4cy4AE7spP1IX5Jq7VCAxHHMfQ==",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@sigstore/sign": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.3.tgz",
-			"integrity": "sha512-LqlA+ffyN02yC7RKszCdMTS6bldZnIodiox+IkT8B2f8oRYXCB3LQ9roXeiEL21m64CVH1wyveYAORfD65WoSw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
+			"integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
 			"dependencies": {
-				"@sigstore/bundle": "^2.2.0",
+				"@sigstore/bundle": "^2.3.0",
 				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.0",
+				"@sigstore/protobuf-specs": "^0.3.1",
 				"make-fetch-happen": "^13.0.0"
 			},
 			"engines": {
@@ -2476,13 +2484,13 @@
 			}
 		},
 		"node_modules/@sigstore/verify": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.1.1.tgz",
-			"integrity": "sha512-BNANJms49rw9Q5J+fJjrDqOQSzjXDcOq/pgKDaVdDoIvQwqIfaoUriy+fQfh8sBX04hr4bkkrwu3EbhQqoQH7A==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.2.0.tgz",
+			"integrity": "sha512-hQF60nc9yab+Csi4AyoAmilGNfpXT+EXdBgFkP9OgPwIBPwyqVf7JAWPtmqrrrneTmAT6ojv7OlH1f6Ix5BG4Q==",
 			"dependencies": {
-				"@sigstore/bundle": "^2.2.0",
+				"@sigstore/bundle": "^2.3.1",
 				"@sigstore/core": "^1.1.0",
-				"@sigstore/protobuf-specs": "^0.3.0"
+				"@sigstore/protobuf-specs": "^0.3.1"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
@@ -2657,9 +2665,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
-			"integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
+			"version": "8.56.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
+			"integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -2718,9 +2726,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.12.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-			"integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+			"version": "20.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
+			"integrity": "sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -2794,16 +2802,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
-			"integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.5.0.tgz",
+			"integrity": "sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/type-utils": "7.4.0",
-				"@typescript-eslint/utils": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/type-utils": "7.5.0",
+				"@typescript-eslint/utils": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2829,13 +2837,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-			"integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
+			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0"
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -2846,9 +2854,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -2859,13 +2867,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-			"integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
+			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2887,17 +2895,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
-			"integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
+			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/typescript-estree": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2912,12 +2920,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-			"integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
+			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2929,15 +2937,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
-			"integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
+			"integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/typescript-estree": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2957,13 +2965,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-			"integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
+			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0"
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -2974,9 +2982,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -2987,13 +2995,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-			"integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
+			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -3015,12 +3023,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-			"integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
+			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -3049,13 +3057,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
-			"integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
+			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.4.0",
-				"@typescript-eslint/utils": "7.4.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
+				"@typescript-eslint/utils": "7.5.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -3076,13 +3084,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-			"integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
+			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0"
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -3093,9 +3101,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -3106,13 +3114,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-			"integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
+			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -3134,17 +3142,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
-			"integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
+			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/typescript-estree": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -3159,12 +3167,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-			"integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
+			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -4292,9 +4300,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001600",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+			"version": "1.0.30001606",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+			"integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -5309,9 +5317,9 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.722",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.722.tgz",
-			"integrity": "sha512-5nLE0TWFFpZ80Crhtp4pIp8LXCztjYX41yUcV6b+bKR2PqzjskTMOOlBi1VjBHlvHwS+4gar7kNKOrsbsewEZQ==",
+			"version": "1.4.728",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.728.tgz",
+			"integrity": "sha512-Ud1v7hJJYIqehlUJGqR6PF1Ek8l80zWwxA6nGxigBsGJ9f9M2fciHyrIiNMerSHSH3p+0/Ia7jIlnDkt41h5cw==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -7628,9 +7636,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.8",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-			"integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+			"version": "0.30.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
+			"integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -9842,10 +9850,11 @@
 			}
 		},
 		"node_modules/pacote/node_modules/npm-registry-fetch": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.1.0.tgz",
-			"integrity": "sha512-PQCELXKt8Azvxnt5Y85GseQDJJlglTFM9L9U9gkv2y4e9s0k3GVDdOx3YoB6gm2Do0hlkzC39iCGXby+Wve1Bw==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
+			"integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
 			"dependencies": {
+				"@npmcli/redact": "^1.1.0",
 				"make-fetch-happen": "^13.0.0",
 				"minipass": "^7.0.2",
 				"minipass-fetch": "^3.0.0",
@@ -10493,9 +10502,9 @@
 			}
 		},
 		"node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
-			"integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+			"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
 			"engines": {
 				"node": ">=16"
 			},
@@ -10574,9 +10583,9 @@
 			}
 		},
 		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
-			"integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+			"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
 			"engines": {
 				"node": ">=16"
 			},
@@ -10921,16 +10930,16 @@
 			}
 		},
 		"node_modules/sigstore": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.2.2.tgz",
-			"integrity": "sha512-2A3WvXkQurhuMgORgT60r6pOWiCOO5LlEqY2ADxGBDGVYLSo5HN0uLtb68YpVpuL/Vi8mLTe7+0Dx2Fq8lLqEg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.3.0.tgz",
+			"integrity": "sha512-q+o8L2ebiWD1AxD17eglf1pFrl9jtW7FHa0ygqY6EKvibK8JHyq9Z26v9MZXeDiw+RbfOJ9j2v70M10Hd6E06A==",
 			"dependencies": {
-				"@sigstore/bundle": "^2.2.0",
+				"@sigstore/bundle": "^2.3.1",
 				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.0",
-				"@sigstore/sign": "^2.2.3",
+				"@sigstore/protobuf-specs": "^0.3.1",
+				"@sigstore/sign": "^2.3.0",
 				"@sigstore/tuf": "^2.3.1",
-				"@sigstore/verify": "^1.1.0"
+				"@sigstore/verify": "^1.2.0"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
@@ -11505,9 +11514,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.30.0.tgz",
-			"integrity": "sha512-Y/SblUl5kEyEFzhMAQdsxVHh+utAxd4IuRNJzKywY/4uzSogh3G219jqbDDxYu4MXO9CzY3tSEqmZvW6AoEDJw==",
+			"version": "5.30.3",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
+			"integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -11652,9 +11661,9 @@
 			}
 		},
 		"node_modules/tsx": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.1.tgz",
-			"integrity": "sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.2.tgz",
+			"integrity": "sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "~0.19.10",
@@ -11735,14 +11744,14 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.4.0.tgz",
-			"integrity": "sha512-8GYQsb/joknlAZEAs/kqonfrsAc98C5DoellmwHREPqKwSTKSY2YB93IwmvNuX6+WE5QkKc31X9wHo/UcpYXpw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.5.0.tgz",
+			"integrity": "sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "7.4.0",
-				"@typescript-eslint/parser": "7.4.0",
-				"@typescript-eslint/utils": "7.4.0"
+				"@typescript-eslint/eslint-plugin": "7.5.0",
+				"@typescript-eslint/parser": "7.5.0",
+				"@typescript-eslint/utils": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -11761,13 +11770,13 @@
 			}
 		},
 		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-			"integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
+			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0"
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -11778,9 +11787,9 @@
 			}
 		},
 		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -11791,13 +11800,13 @@
 			}
 		},
 		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-			"integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
+			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/visitor-keys": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/visitor-keys": "7.5.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -11819,17 +11828,17 @@
 			}
 		},
 		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
-			"integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
+			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.4.0",
-				"@typescript-eslint/types": "7.4.0",
-				"@typescript-eslint/typescript-estree": "7.4.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -11844,12 +11853,12 @@
 			}
 		},
 		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-			"integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
+			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.4.0",
+				"@typescript-eslint/types": "7.5.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {


### PR DESCRIPTION
Its a try to get dependabot start analyzing the lockfile.
Currently, npm-shrinkwrap.json is not supported officially by dependabot.
