### PR TITLE
deps: Bump @sapui5/types to 1.120.13

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"@sapui5/types": "1.120.12",
+				"@sapui5/types": "1.120.13",
 				"@ui5/fs": "^3.0.5",
 				"@ui5/logger": "^3.0.0",
 				"@ui5/project": "^3.9.1",
@@ -2806,9 +2806,9 @@
 			}
 		},
 		"node_modules/@sapui5/types": {
-			"version": "1.120.12",
-			"resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.120.12.tgz",
-			"integrity": "sha512-ZFNQ73RrGZPOH1hEQoDJezQvTL9QDaou1K0K6nMnH/Zc2nIuB40YMpCiaav67emhxRkpQ/+jqw4bsJG/3FD6EQ==",
+			"version": "1.120.13",
+			"resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.120.13.tgz",
+			"integrity": "sha512-PZGmlNv4cNJAr6HYc4+5zAwATJDzzFLsN4d9SDENOTSf2LO0MzOgk49igPuuRGI/cfyUGChVi6Eh4mMD36Y23g==",
 			"dependencies": {
 				"@types/jquery": "3.5.13",
 				"@types/offscreencanvas": "2019.6.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	"dependencies": {
 		"@jridgewell/sourcemap-codec": "^1.4.15",
 		"@jridgewell/trace-mapping": "^0.3.25",
-		"@sapui5/types": "1.120.12",
+		"@sapui5/types": "1.120.13",
 		"@ui5/fs": "^3.0.5",
 		"@ui5/logger": "^3.0.0",
 		"@ui5/project": "^3.9.1",


### PR DESCRIPTION
This change updates `@sapui5/types` to 1.120.13 which is vital for https://github.com/SAP/ui5-linter/pull/73