### PR TITLE
fix: Disable TS-compiler checks for JavaScript resources

### DIFF
--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -22,7 +22,7 @@ const DEFAULT_OPTIONS: ts.CompilerOptions = {
 	lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
 	// Allow and check JavaScript files since this is everything we'll do here
 	allowJs: true,
-	checkJs: true,
+	checkJs: false,
 	strict: true,
 	noImplicitAny: false,
 	strictNullChecks: false,

--- a/src/linter/ui5Types/amdTranspiler/transpiler.ts
+++ b/src/linter/ui5Types/amdTranspiler/transpiler.ts
@@ -32,7 +32,7 @@ function createCompilerHost(sourceFiles: SourceFiles, writtenFiles: WrittenFiles
 
 const compilerOptions = {
 	moduleResolution: ts.ModuleResolutionKind.NodeNext,
-	checkJs: true,
+	checkJs: false,
 	allowJs: true,
 	skipLibCheck: true,
 


### PR DESCRIPTION
Disable error reporting for JavaScript resources. We don't retrieve the reported errors anyways. This change significantly improves the speed of the AMD to ESM transpiler as well as the type checker.

For the transpiler, setting this flag only takes effect since TypeScript v5.5.2 (which we are using now).

## Measurements

*Based on https://github.com/SAP/ui5-linter/blob/main/docs/PERFORMANCE.md#large-library-openui5-sapm*

ui5-linter Ref | Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|:---|---:|---:|---:|---:|
| b81d416 (main) | `ui5lint` | 37.806 ± 0.828 | 37.120 | 39.611 | Baseline |
| 3fba8f6 (this PR) | `ui5lint` | 32.798 ± 0.957 | 31.587 | 34.433 | **-13%** |