### PR TITLE
feat!: Drop support for node v18, v21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 18.14.2
+    - name: Use Node.js 20.11.0
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 18.14.2
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci
@@ -32,7 +32,7 @@ jobs:
 
     - name: Perform build
       run: npm run build-test
-      
+
     - name: Run unit tests
       run: npm run coverage
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Use Node.js 21.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:
-        node-version: 21.x
+        node-version: 20.x
     - name: Install dependencies
       run: npm ci
     - name: Run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [18, 20, 21]
+        version: [20, 22]
         os: [ubuntu-22.04, windows-2022, macos-14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
 		".reuse/**"
 	],
 	"engines": {
-		"node": "^18.14.2 || ^20.11.0 || >=21.2.0",
-		"npm": ">= 9.5.0"
+		"node": "^20.11.0 || >=22.0.0",
+		"npm": ">= 8"
 	},
 	"dependencies": {
 		"@jridgewell/sourcemap-codec": "^1.5.0",


### PR DESCRIPTION
BREAKING CHANGE: Support for older Node.js has been dropped.
Only Node.js 20.11.x and >=22.0.0 as well as npm v8 or higher are supported.

JIRA: CPOUI5FOUNDATION-833
