### PR TITLE
deps: Downgrade transitive dependencies to resolve coverage errors

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -62,6 +62,13 @@
 				"npm": ">= 8"
 			}
 		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
+			"integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -88,30 +95,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
-			"integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-			"integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.9",
-				"@babel/helper-compilation-targets": "^7.24.8",
-				"@babel/helper-module-transforms": "^7.24.9",
-				"@babel/helpers": "^7.24.8",
-				"@babel/parser": "^7.24.8",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helpers": "^7.24.7",
+				"@babel/parser": "^7.24.7",
 				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.8",
-				"@babel/types": "^7.24.9",
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -136,12 +143,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
-			"integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+			"integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.24.9",
+				"@babel/types": "^7.24.7",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -151,14 +158,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
-			"integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.24.8",
-				"@babel/helper-validator-option": "^7.24.8",
-				"browserslist": "^4.23.1",
+				"@babel/compat-data": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -226,9 +233,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
-			"integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.24.7",
@@ -245,9 +252,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-			"integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+			"integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -279,9 +286,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -296,22 +303,22 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-			"integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.8"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -383,10 +390,10 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
-			"integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
-			"dev": true,
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+			"devOptional": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -395,9 +402,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-			"integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+			"integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -421,19 +428,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
-			"integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+			"integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.8",
+				"@babel/generator": "^7.24.7",
 				"@babel/helper-environment-visitor": "^7.24.7",
 				"@babel/helper-function-name": "^7.24.7",
 				"@babel/helper-hoist-variables": "^7.24.7",
 				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/parser": "^7.24.8",
-				"@babel/types": "^7.24.8",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -442,12 +449,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
-			"integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.24.8",
+				"@babel/helper-string-parser": "^7.24.7",
 				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
@@ -1493,7 +1500,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
 			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1515,9 +1522,20 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -1532,6 +1550,19 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jsdoc/salty": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+			"integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=v12.0.0"
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp": {
@@ -1560,6 +1591,41 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1568,6 +1634,33 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/glob": {
@@ -1589,6 +1682,28 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/minimatch": {
@@ -1618,6 +1733,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"are-we-there-yet": "^2.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^3.0.0",
+				"set-blocking": "^2.0.0"
+			}
+		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1632,6 +1760,38 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1946,33 +2106,13 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/@npmcli/agent/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.1.tgz",
+			"integrity": "sha512-9/8QXrtbGeMB6LxwQd4x1tIMnsmUxMvIH/qWGsccz6bt9Uln3S+sgAaqfQNhbGA8ufzs2fHuP/yqapGgP9Hh2g==",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@npmcli/arborist": {
 			"version": "6.5.1",
@@ -2016,55 +2156,6 @@
 			},
 			"bin": {
 				"arborist": "bin/index.js"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@npmcli/git": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
-			"integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
-			"dev": true,
-			"dependencies": {
-				"@npmcli/promise-spawn": "^6.0.0",
-				"lru-cache": "^7.4.4",
-				"npm-pick-manifest": "^8.0.0",
-				"proc-log": "^3.0.0",
-				"promise-inflight": "^1.0.1",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@npmcli/package-json": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-4.0.1.tgz",
-			"integrity": "sha512-lRCEGdHZomFsURroh522YvA/2cVb9oPIJrjHanCJZkiasz1BzcnLr3tBJhlV7S86MBJBuAQ33is2D60YitZL2Q==",
-			"dev": true,
-			"dependencies": {
-				"@npmcli/git": "^4.1.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^6.1.1",
-				"json-parse-even-better-errors": "^3.0.0",
-				"normalize-package-data": "^5.0.0",
-				"proc-log": "^3.0.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@npmcli/promise-spawn": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-			"integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
-			"dev": true,
-			"dependencies": {
-				"which": "^3.0.0"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2140,61 +2231,16 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/are-we-there-yet": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
-			"integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
-			"deprecated": "This package is no longer supported.",
-			"dev": true,
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"node_modules/@npmcli/arborist/node_modules/gauge": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
-			"integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
-			"deprecated": "This package is no longer supported.",
+		"node_modules/@npmcli/arborist/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
 			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.3",
-				"console-control-strings": "^1.1.0",
-				"has-unicode": "^2.0.1",
-				"signal-exit": "^4.0.1",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.5"
+				"debug": "4"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-			"integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^7.5.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/http-proxy-agent": {
@@ -2211,20 +2257,18 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+		"node_modules/@npmcli/arborist/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">= 6"
 			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
 		},
 		"node_modules/@npmcli/arborist/node_modules/lru-cache": {
 			"version": "7.18.3",
@@ -2270,21 +2314,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/normalize-package-data": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-			"integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^6.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/npm-packlist": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-7.0.4.tgz",
@@ -2292,37 +2321,6 @@
 			"dev": true,
 			"dependencies": {
 				"ignore-walk": "^6.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npm-pick-manifest": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
-			"integrity": "sha512-1dKY+86/AIiq1tkKVD3l0WI+Gd3vkknVGAggsFeBkTvbhMQ1OND/LKkYv4JtXPKUJ8bOTCyLiqEg2P6QNdK+Gg==",
-			"dev": true,
-			"dependencies": {
-				"npm-install-checks": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^10.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npmlog": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-			"integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-			"deprecated": "This package is no longer supported.",
-			"dev": true,
-			"dependencies": {
-				"are-we-there-yet": "^4.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^5.0.0",
-				"set-blocking": "^2.0.0"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2402,32 +2400,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/tuf-js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-1.1.7.tgz",
@@ -2442,25 +2414,11 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/which": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/config": {
 			"version": "8.3.4",
 			"resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.3.4.tgz",
 			"integrity": "sha512-01rtHedemDNhUXdicU7s+QYz/3JyV5Naj84cvdXGH4mgCdL+agmSYaLF4LUG4vMCLzhBO8YtS0gPpH1FGvbgAw==",
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/map-workspaces": "^3.0.2",
 				"@npmcli/package-json": "^5.1.1",
@@ -2475,21 +2433,11 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/git": {
+		"node_modules/@npmcli/config/node_modules/@npmcli/git": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
 			"integrity": "sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==",
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/promise-spawn": "^7.0.0",
 				"ini": "^4.1.3",
@@ -2505,10 +2453,184 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/git/node_modules/lru-cache": {
+		"node_modules/@npmcli/config/node_modules/@npmcli/package-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.0.tgz",
+			"integrity": "sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^7.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"normalize-package-data": "^6.0.0",
+				"proc-log": "^4.0.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/@npmcli/promise-spawn": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+			"integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+			"license": "ISC",
+			"dependencies": {
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/isexe": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/lru-cache": {
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
+		},
+		"node_modules/@npmcli/config/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/npm-package-arg": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"proc-log": "^4.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/npm-pick-manifest": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
+			"integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"npm-package-arg": "^11.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/config/node_modules/which": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/fs": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/git": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
+			"integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
+			"dev": true,
+			"dependencies": {
+				"@npmcli/promise-spawn": "^6.0.0",
+				"lru-cache": "^7.4.4",
+				"npm-pick-manifest": "^8.0.0",
+				"proc-log": "^3.0.0",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/proc-log": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+			"integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+			"dev": true,
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/@npmcli/installed-package-contents": {
 			"version": "2.1.0",
@@ -2549,37 +2671,6 @@
 				"json-parse-even-better-errors": "^3.0.0",
 				"pacote": "^15.0.0",
 				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/git": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
-			"integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
-			"dev": true,
-			"dependencies": {
-				"@npmcli/promise-spawn": "^6.0.0",
-				"lru-cache": "^7.4.4",
-				"npm-pick-manifest": "^8.0.0",
-				"proc-log": "^3.0.0",
-				"promise-inflight": "^1.0.1",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/promise-spawn": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-			"integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
-			"dev": true,
-			"dependencies": {
-				"which": "^3.0.0"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2655,6 +2746,18 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/http-proxy-agent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -2669,11 +2772,18 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+		"node_modules/@npmcli/metavuln-calculator/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
 			"version": "7.18.3",
@@ -2726,21 +2836,6 @@
 			"dev": true,
 			"dependencies": {
 				"ignore-walk": "^6.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/npm-pick-manifest": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
-			"integrity": "sha512-1dKY+86/AIiq1tkKVD3l0WI+Gd3vkknVGAggsFeBkTvbhMQ1OND/LKkYv4JtXPKUJ8bOTCyLiqEg2P6QNdK+Gg==",
-			"dev": true,
-			"dependencies": {
-				"npm-install-checks": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^10.0.0",
-				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2829,21 +2924,6 @@
 				"@tufjs/models": "1.0.4",
 				"debug": "^4.3.4",
 				"make-fetch-happen": "^11.1.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/which": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2939,31 +3019,57 @@
 			}
 		},
 		"node_modules/@npmcli/package-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.0.tgz",
-			"integrity": "sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha512-lRCEGdHZomFsURroh522YvA/2cVb9oPIJrjHanCJZkiasz1BzcnLr3tBJhlV7S86MBJBuAQ33is2D60YitZL2Q==",
+			"dev": true,
 			"dependencies": {
-				"@npmcli/git": "^5.0.0",
+				"@npmcli/git": "^4.1.0",
 				"glob": "^10.2.2",
-				"hosted-git-info": "^7.0.0",
+				"hosted-git-info": "^6.1.1",
 				"json-parse-even-better-errors": "^3.0.0",
-				"normalize-package-data": "^6.0.0",
-				"proc-log": "^4.0.0",
+				"normalize-package-data": "^5.0.0",
+				"proc-log": "^3.0.0",
 				"semver": "^7.5.3"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/proc-log": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+			"integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+			"dev": true,
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@npmcli/promise-spawn": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
-			"integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
+			"integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+			"dev": true,
 			"dependencies": {
-				"which": "^4.0.0"
+				"which": "^3.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/promise-spawn/node_modules/which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@npmcli/query": {
@@ -3001,24 +3107,6 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/@npmcli/promise-spawn": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-			"integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
-			"dev": true,
-			"dependencies": {
-				"which": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
 		},
 		"node_modules/@npmcli/run-script/node_modules/which": {
 			"version": "3.0.1",
@@ -3380,9 +3468,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.11",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
-			"integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
+			"version": "8.56.10",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+			"integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -3415,6 +3503,31 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -3433,7 +3546,8 @@
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/offscreencanvas": {
 			"version": "2019.6.4",
@@ -3748,6 +3862,186 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"node_modules/@ui5/builder": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.5.0.tgz",
+			"integrity": "sha512-Z7/4Nh5/Pc2vBnAbAahleXe7CEj0OVFpPnQFizp+wYE60XR7748ea2wSt7NoKB3HStDzGS8lvWnJ3SqBzAyDDA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@ui5/fs": "^3.0.5",
+				"@ui5/logger": "^3.0.0",
+				"cheerio": "1.0.0-rc.12",
+				"escape-unicode": "^0.2.0",
+				"escope": "^4.0.0",
+				"espree": "^9.6.1",
+				"graceful-fs": "^4.2.11",
+				"jsdoc": "^4.0.3",
+				"less-openui5": "^0.11.6",
+				"pretty-data": "^0.40.0",
+				"rimraf": "^5.0.7",
+				"semver": "^7.6.2",
+				"terser": "^5.31.1",
+				"workerpool": "^6.5.1",
+				"xml2js": "^0.6.2"
+			},
+			"engines": {
+				"node": "^16.18.0 || >=18.12.0",
+				"npm": ">= 8"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/@ui5/fs": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@ui5/fs/-/fs-3.0.5.tgz",
+			"integrity": "sha512-SpDoMvOGYeBR8xOTDb1cu0uxJNsC1FxrENsZiRMd6R2PfUAiR0fiWQHn4dVBspoLx+jFemAfLfTMv1DEn0m1qQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@ui5/logger": "^3.0.0",
+				"clone": "^2.1.2",
+				"escape-string-regexp": "^5.0.0",
+				"globby": "^13.2.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.5",
+				"minimatch": "^9.0.3",
+				"pretty-hrtime": "^1.0.3",
+				"random-int": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.18.0 || >=18.12.0",
+				"npm": ">= 8"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/@ui5/logger": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ui5/logger/-/logger-3.0.0.tgz",
+			"integrity": "sha512-Np9pHhr+dnyL2gDFwIx6c6Xy0yhtpBIqUQM9An8uLX/wIcRjIjBSQ/r16o3YgS9roY59I/uj5ZEbIa1cdS3Dzg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"chalk": "^5.2.0",
+				"cli-progress": "^3.11.2",
+				"figures": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.18.0 || >=18.12.0",
+				"npm": ">= 8"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/figures": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+			"integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"escape-string-regexp": "^5.0.0",
+				"is-unicode-supported": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/globby": {
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.3.0",
+				"ignore": "^5.2.4",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/rimraf": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.9.tgz",
+			"integrity": "sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "14 >=14.20 || 16 >=16.20 || >=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@ui5/fs": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@ui5/fs/-/fs-4.0.0.tgz",
@@ -3841,6 +4135,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.0.tgz",
 			"integrity": "sha512-C30g6H/BPj1dAVwjI0cvohbdz+p6TtUvc4lzBLwnaHiIMIeDPrs41umc5Y1Wh/Z++XbPwr0rbbKlmdCDvXZ/CQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@npmcli/config": "^8.3.4",
 				"@ui5/fs": "^4.0.0",
@@ -3902,6 +4197,7 @@
 			"version": "14.0.2",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
 			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^2.1.0",
 				"fast-glob": "^3.3.2",
@@ -3937,6 +4233,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
 			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -3948,6 +4245,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
 			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -4031,59 +4329,59 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.4.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.33.tgz",
-			"integrity": "sha512-MoIREbkdPQlnGfSKDMgzTqzqx5nmEjIc0ydLVYlTACGBsfvOJ4tHSbZXKVF536n6fB+0eZaGEOqsGThPpdvF5A==",
+			"version": "3.4.31",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.31.tgz",
+			"integrity": "sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.24.7",
-				"@vue/shared": "3.4.33",
+				"@vue/shared": "3.4.31",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.0"
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.4.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.33.tgz",
-			"integrity": "sha512-GzB8fxEHKw0gGet5BKlpfXEqoBnzSVWwMnT+dc25wE7pFEfrU/QsvjZMP9rD4iVXHBBoemTct8mN0GJEI6ZX5A==",
+			"version": "3.4.31",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz",
+			"integrity": "sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-core": "3.4.33",
-				"@vue/shared": "3.4.33"
+				"@vue/compiler-core": "3.4.31",
+				"@vue/shared": "3.4.31"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.4.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.33.tgz",
-			"integrity": "sha512-7rk7Vbkn21xMwIUpHQR4hCVejwE6nvhBOiDgoBcR03qvGqRKA7dCBSsHZhwhYUsmjlbJ7OtD5UFIyhP6BY+c8A==",
+			"version": "3.4.31",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.31.tgz",
+			"integrity": "sha512-einJxqEw8IIJxzmnxmJBuK2usI+lJonl53foq+9etB2HAzlPjAS/wa7r0uUpXw5ByX3/0uswVSrjNb17vJm1kQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.24.7",
-				"@vue/compiler-core": "3.4.33",
-				"@vue/compiler-dom": "3.4.33",
-				"@vue/compiler-ssr": "3.4.33",
-				"@vue/shared": "3.4.33",
+				"@vue/compiler-core": "3.4.31",
+				"@vue/compiler-dom": "3.4.31",
+				"@vue/compiler-ssr": "3.4.31",
+				"@vue/shared": "3.4.31",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.30.10",
-				"postcss": "^8.4.39",
+				"postcss": "^8.4.38",
 				"source-map-js": "^1.2.0"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.4.33",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.33.tgz",
-			"integrity": "sha512-0WveC9Ai+eT/1b6LCV5IfsufBZ0HP7pSSTdDjcuW302tTEgoBw8rHVHKPbGUtzGReUFCRXbv6zQDDgucnV2WzQ==",
+			"version": "3.4.31",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.31.tgz",
+			"integrity": "sha512-RtefmITAje3fJ8FSg1gwgDhdKhZVntIVbwupdyZDSifZTRMiWxWehAOTCc8/KZDnBOcYQ4/9VWxsTbd3wT0hAA==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.33",
-				"@vue/shared": "3.4.33"
+				"@vue/compiler-dom": "3.4.31",
+				"@vue/shared": "3.4.31"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.4.33",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.33.tgz",
-			"integrity": "sha512-aoRY0jQk3A/cuvdkodTrM4NMfxco8n55eG4H7ML/CRy7OryHfiqvug4xrCBBMbbN+dvXAetDDwZW9DXWWjBntA==",
+			"version": "3.4.31",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
+			"integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==",
 			"dev": true
 		},
 		"node_modules/abbrev": {
@@ -4098,7 +4396,7 @@
 			"version": "8.12.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
 			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"dev": true,
+			"devOptional": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4119,7 +4417,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
+			"devOptional": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -4137,15 +4435,14 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dependencies": {
-				"debug": "4"
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/agentkeepalive": {
@@ -4160,35 +4457,15 @@
 				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/aggregate-error/node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.4.1"
 			},
 			"funding": {
 				"type": "github",
@@ -4303,17 +4580,13 @@
 			"dev": true
 		},
 		"node_modules/are-we-there-yet": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
+			"integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
 			"deprecated": "This package is no longer supported.",
 			"dev": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/argparse": {
@@ -4557,11 +4830,25 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"node_modules/bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/blueimp-md5": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/boxen": {
 			"version": "7.1.1",
@@ -4615,9 +4902,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-			"integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+			"integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4634,10 +4921,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001640",
-				"electron-to-chromium": "^1.4.820",
+				"caniuse-lite": "^1.0.30001629",
+				"electron-to-chromium": "^1.4.796",
 				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.1.0"
+				"update-browserslist-db": "^1.0.16"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4645,6 +4932,13 @@
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cacache": {
 			"version": "17.1.4",
@@ -4667,6 +4961,37 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/cacache/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cacache/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cacache/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/cacache/node_modules/lru-cache": {
@@ -4757,9 +5082,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001643",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
-			"integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
+			"version": "1.0.30001640",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+			"integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4775,6 +5100,19 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
+		},
+		"node_modules/catharsis": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lodash": "^4.17.15"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
 		},
 		"node_modules/cbor": {
 			"version": "9.0.2",
@@ -4797,6 +5135,46 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cheerio": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/chownr": {
@@ -4832,14 +5210,6 @@
 			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
 			"integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
 			"dev": true
-		},
-		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/cli-boxes": {
 			"version": "3.0.0",
@@ -5102,6 +5472,13 @@
 				"color-support": "bin.js"
 			}
 		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/common-ancestor-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -5363,25 +5740,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cross-spawn/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-		},
-		"node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/crypto-random-string": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
@@ -5405,6 +5763,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/cssesc": {
@@ -5823,7 +6211,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -5852,6 +6240,65 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/dot-prop": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -5870,9 +6317,9 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.0.tgz",
-			"integrity": "sha512-Vb3xHHYnLseK8vlMJQKJYXJ++t4u1/qJ3vykuVrVjvdiOEhYyT1AuP4x03G8EnPmYvYOhe9T+dADTmthjRQMkA==",
+			"version": "1.4.818",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.818.tgz",
+			"integrity": "sha512-eGvIk2V0dGImV9gWLq8fDfTTsCAeMDwZqEPMr+jMInxZdnp9Us8UpovYpRCf9NQ7VOFgrN2doNSgvISbsbNpxA==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -5905,7 +6352,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -6028,6 +6475,40 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/escape-unicode": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
+			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/escope": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
+			"integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/escope/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -6269,6 +6750,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/eslint/node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -6444,9 +6937,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -6459,7 +6952,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -6471,7 +6964,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -6557,17 +7050,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6578,11 +7060,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
-		},
-		"node_modules/fast-uri": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
@@ -6864,24 +7341,23 @@
 			}
 		},
 		"node_modules/gauge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
+			"integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
 			"deprecated": "This package is no longer supported.",
 			"dev": true,
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
 				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
+				"signal-exit": "^4.0.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
+				"wide-align": "^1.1.5"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/gauge/node_modules/ansi-regex": {
@@ -6907,12 +7383,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/gauge/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
 		},
 		"node_modules/gauge/node_modules/string-width": {
 			"version": "4.2.3",
@@ -7010,9 +7480,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.7.6",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.6.tgz",
-			"integrity": "sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+			"integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
 			"dev": true,
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -7039,9 +7509,9 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.3.tgz",
+			"integrity": "sha512-Q38SGlYRpVtDBPSWEylRyctn7uDeTp4NQERTLiCT1FqA9JXPYWqAVmQU6qh4r/zMM5ehxTcbaO8EjhWnvEhmyg==",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
 				"jackspeak": "^3.1.2",
@@ -7053,20 +7523,22 @@
 			"bin": {
 				"glob": "dist/esm/bin.mjs"
 			},
+			"engines": {
+				"node": ">=18"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dependencies": {
-				"is-glob": "^4.0.3"
+				"is-glob": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/global-directory": {
@@ -7125,12 +7597,6 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
-		},
-		"node_modules/global-prefix/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
 		"node_modules/global-prefix/node_modules/which": {
@@ -7342,26 +7808,51 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+			"integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+			"dev": true,
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
+		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
@@ -7380,28 +7871,16 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/http-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
 			"dependencies": {
-				"agent-base": "6",
+				"agent-base": "^7.0.2",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/human-signals": {
@@ -7544,6 +8023,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
 			"integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -7578,6 +8058,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
 			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
@@ -7615,9 +8096,9 @@
 			"dev": true
 		},
 		"node_modules/is-core-module": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-			"integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
 			"dependencies": {
 				"hasown": "^2.0.2"
 			},
@@ -7818,12 +8299,9 @@
 			}
 		},
 		"node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-			"engines": {
-				"node": ">=16"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -7888,6 +8366,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istanbul-lib-processinfo/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7896,6 +8387,15 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/istanbul-lib-processinfo/node_modules/glob": {
@@ -7917,6 +8417,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/istanbul-lib-processinfo/node_modules/minimatch": {
@@ -8016,11 +8525,14 @@
 			}
 		},
 		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.1.tgz",
+			"integrity": "sha512-U23pQPDnmYybVkYjObcuYMk43VRlMLLqLI+RdZy8s8WV8WsxO9SnqSroKaluuvcNOdCAlauKszDwd+umbot5Mg==",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -8065,10 +8577,60 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/js2xmlparser": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"xmlcreate": "^2.0.4"
+			}
+		},
 		"node_modules/jsbn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+		},
+		"node_modules/jsdoc": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
+			"integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/parser": "^7.20.15",
+				"@jsdoc/salty": "^0.2.1",
+				"@types/markdown-it": "^14.1.1",
+				"bluebird": "^3.7.2",
+				"catharsis": "^0.9.0",
+				"escape-string-regexp": "^2.0.0",
+				"js2xmlparser": "^4.0.2",
+				"klaw": "^3.0.0",
+				"markdown-it": "^14.1.0",
+				"markdown-it-anchor": "^8.6.7",
+				"marked": "^4.0.10",
+				"mkdirp": "^1.0.4",
+				"requizzle": "^0.2.3",
+				"strip-json-comments": "^3.1.0",
+				"underscore": "~1.13.2"
+			},
+			"bin": {
+				"jsdoc": "jsdoc.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/jsdoc/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
@@ -8205,6 +8767,16 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/klaw": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.9"
+			}
+		},
 		"node_modules/ky": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ky/-/ky-1.4.0.tgz",
@@ -8228,6 +8800,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/less-openui5": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/less-openui5/-/less-openui5-0.11.6.tgz",
+			"integrity": "sha512-sQmU+G2pJjFfzRI+XtXkk+T9G0s6UmWWUfOW0utPR46C9lfhNr4DH1lNJuImj64reXYi+vOwyNxPRkj0F3mofA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@adobe/css-tools": "^4.0.2",
+				"clone": "^2.1.2",
+				"mime": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 10",
+				"npm": ">= 5"
 			}
 		},
 		"node_modules/levn": {
@@ -8274,6 +8862,16 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/load-json-file": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-7.0.1.tgz",
@@ -8318,7 +8916,7 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
@@ -8450,10 +9048,22 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/make-fetch-happen/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/make-fetch-happen/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+			"version": "18.0.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
+			"integrity": "sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==",
 			"dependencies": {
 				"@npmcli/fs": "^3.1.0",
 				"fs-minipass": "^3.0.0",
@@ -8472,10 +9082,29 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/make-fetch-happen/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/make-fetch-happen/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.1.tgz",
+			"integrity": "sha512-9/8QXrtbGeMB6LxwQd4x1tIMnsmUxMvIH/qWGsccz6bt9Uln3S+sgAaqfQNhbGA8ufzs2fHuP/yqapGgP9Hh2g==",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/make-fetch-happen/node_modules/minipass-collect": {
 			"version": "2.0.1",
@@ -8500,6 +9129,55 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it-anchor": {
+			"version": "8.6.7",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+			"integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+			"optional": true,
+			"peer": true,
+			"peerDependencies": {
+				"@types/markdown-it": "*",
+				"markdown-it": "*"
+			}
+		},
+		"node_modules/markdown-it/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/matcher": {
@@ -8528,6 +9206,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/memoize": {
 			"version": "10.0.0",
@@ -8591,6 +9276,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -9017,6 +9715,31 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"node_modules/node-gyp/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/node-gyp/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/node-gyp/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -9120,6 +9843,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/node-gyp/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/node-gyp/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9193,6 +9925,28 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/node-gyp/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/node-gyp/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -9201,12 +9955,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/node-gyp/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
 		},
 		"node_modules/node-gyp/node_modules/lru-cache": {
 			"version": "7.18.3",
@@ -9429,21 +10177,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/node-gyp/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/node-gyp/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -9463,9 +10196,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"node_modules/node-stream-zip": {
@@ -9504,16 +10237,18 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
+			"integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+			"dev": true,
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
+				"hosted-git-info": "^6.0.0",
+				"is-core-module": "^2.8.1",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/npm-bundled": {
@@ -9567,27 +10302,6 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/npm-package-arg/node_modules/hosted-git-info": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-			"integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^7.5.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm-package-arg/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/npm-package-arg/node_modules/proc-log": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -9609,31 +10323,18 @@
 			}
 		},
 		"node_modules/npm-pick-manifest": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
-			"integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
+			"integrity": "sha512-1dKY+86/AIiq1tkKVD3l0WI+Gd3vkknVGAggsFeBkTvbhMQ1OND/LKkYv4JtXPKUJ8bOTCyLiqEg2P6QNdK+Gg==",
+			"dev": true,
 			"dependencies": {
 				"npm-install-checks": "^6.0.0",
 				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^11.0.0",
+				"npm-package-arg": "^10.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/npm-registry-fetch": {
@@ -9654,6 +10355,18 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/npm-registry-fetch/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/npm-registry-fetch/node_modules/http-proxy-agent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -9661,6 +10374,19 @@
 			"dev": true,
 			"dependencies": {
 				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/npm-registry-fetch/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
 			},
@@ -9763,16 +10489,32 @@
 			}
 		},
 		"node_modules/npmlog": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
+			"integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
 			"deprecated": "This package is no longer supported.",
 			"dev": true,
 			"dependencies": {
-				"are-we-there-yet": "^2.0.0",
+				"are-we-there-yet": "^4.0.0",
 				"console-control-strings": "^1.1.0",
-				"gauge": "^3.0.0",
+				"gauge": "^5.0.0",
 				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
 		"node_modules/nyc": {
@@ -9816,6 +10558,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/nyc/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/nyc/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -9848,6 +10603,15 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/nyc/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/nyc/node_modules/cliui": {
@@ -9936,6 +10700,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/nyc/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/nyc/node_modules/is-fullwidth-code-point": {
@@ -10331,6 +11104,52 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/pacote/node_modules/@npmcli/git": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.7.tgz",
+			"integrity": "sha512-WaOVvto604d5IpdCRV2KjQu8PzkfE96d50CQGKgywXh2GxXmDeUO5EWcBC4V57uFyrNqx83+MewuJh3WTR3xPA==",
+			"dependencies": {
+				"@npmcli/promise-spawn": "^7.0.0",
+				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^9.0.0",
+				"proc-log": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pacote/node_modules/@npmcli/package-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.0.tgz",
+			"integrity": "sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^7.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"normalize-package-data": "^6.0.0",
+				"proc-log": "^4.0.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pacote/node_modules/@npmcli/promise-spawn": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+			"integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+			"dependencies": {
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
 		"node_modules/pacote/node_modules/@npmcli/run-script": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-8.1.0.tgz",
@@ -10347,10 +11166,22 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/pacote/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/pacote/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+			"version": "18.0.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
+			"integrity": "sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==",
 			"dependencies": {
 				"@npmcli/fs": "^3.1.0",
 				"fs-minipass": "^3.0.0",
@@ -10369,10 +11200,48 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/pacote/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pacote/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pacote/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pacote/node_modules/isexe": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/pacote/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.1.tgz",
+			"integrity": "sha512-9/8QXrtbGeMB6LxwQd4x1tIMnsmUxMvIH/qWGsccz6bt9Uln3S+sgAaqfQNhbGA8ufzs2fHuP/yqapGgP9Hh2g==",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/pacote/node_modules/minipass-collect": {
 			"version": "2.0.1",
@@ -10386,9 +11255,9 @@
 			}
 		},
 		"node_modules/pacote/node_modules/node-gyp": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.2.0.tgz",
-			"integrity": "sha512-sp3FonBAaFe4aYTcFdZUn2NYkbP7xroPGYvQmP4Nl5PxamznItBnNCgjrVTKrEfQynInMsJvZrdmqUnysCJ8rw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.1.0.tgz",
+			"integrity": "sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
@@ -10396,9 +11265,9 @@
 				"graceful-fs": "^4.2.6",
 				"make-fetch-happen": "^13.0.0",
 				"nopt": "^7.0.0",
-				"proc-log": "^4.1.0",
+				"proc-log": "^3.0.0",
 				"semver": "^7.3.5",
-				"tar": "^6.2.1",
+				"tar": "^6.1.2",
 				"which": "^4.0.0"
 			},
 			"bin": {
@@ -10408,15 +11277,50 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/pacote/node_modules/node-gyp/node_modules/proc-log": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+			"integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pacote/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
 		"node_modules/pacote/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.2.tgz",
+			"integrity": "sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==",
 			"dependencies": {
 				"hosted-git-info": "^7.0.0",
 				"proc-log": "^4.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-pick-manifest": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.1.tgz",
+			"integrity": "sha512-Udm1f0l2nXb3wxDpKjfohwgdFUSV50UVwzEIpDXVsbDMXVIEF81a/i0UhuQbhrPMMmdiq3+YMFLFIRVLs3hxQw==",
+			"dependencies": {
+				"npm-install-checks": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"npm-package-arg": "^11.0.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
@@ -10452,6 +11356,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pacote/node_modules/which": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/parent-module": {
@@ -10534,6 +11452,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"entities": "^4.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -10581,9 +11526,12 @@
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.1.tgz",
+			"integrity": "sha512-9/8QXrtbGeMB6LxwQd4x1tIMnsmUxMvIH/qWGsccz6bt9Uln3S+sgAaqfQNhbGA8ufzs2fHuP/yqapGgP9Hh2g==",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.2.2",
@@ -10595,7 +11543,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10743,9 +11691,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
-			"integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
+			"integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -10762,6 +11710,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/pretty-data": {
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
+			"integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/pretty-hrtime": {
@@ -10851,6 +11809,16 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -10963,46 +11931,11 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/read-package-json/node_modules/hosted-git-info": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-			"integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^7.5.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-package-json/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/read-package-json/node_modules/normalize-package-data": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-			"integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^6.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/read-package-up": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
 			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"license": "MIT",
 			"dependencies": {
 				"find-up-simple": "^1.0.0",
 				"read-pkg": "^9.0.0",
@@ -11019,6 +11952,7 @@
 			"version": "4.23.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
 			"integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
 			},
@@ -11030,6 +11964,7 @@
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
 			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/normalize-package-data": "^2.4.3",
 				"normalize-package-data": "^6.0.0",
@@ -11044,10 +11979,43 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/read-pkg/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/read-pkg/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
+		},
+		"node_modules/read-pkg/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
 		"node_modules/read-pkg/node_modules/parse-json": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
 			"integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",
 				"index-to-position": "^0.1.2",
@@ -11064,6 +12032,7 @@
 			"version": "4.23.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
 			"integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
 			},
@@ -11179,6 +12148,16 @@
 			"resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
 			"integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
 			"dev": true
+		},
+		"node_modules/requizzle": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+			"integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lodash": "^4.17.21"
+			}
 		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
@@ -11605,22 +12584,11 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/socks-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11632,6 +12600,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/spawn-wrap": {
@@ -11695,12 +12674,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/spawn-wrap/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
-		},
 		"node_modules/spawn-wrap/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11734,21 +12707,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
-		},
-		"node_modules/spawn-wrap/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
 		},
 		"node_modules/spdx-compare": {
 			"version": "1.0.0",
@@ -11997,7 +12955,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -12101,6 +13059,25 @@
 			"dev": true,
 			"engines": {
 				"node": ">=14.16"
+			}
+		},
+		"node_modules/terser": {
+			"version": "5.31.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
+			"integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -12357,6 +13334,20 @@
 				}
 			}
 		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/underscore": {
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -12545,17 +13536,17 @@
 			}
 		},
 		"node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^2.0.0"
 			},
 			"bin": {
-				"node-which": "bin/which.js"
+				"node-which": "bin/node-which"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": ">= 8"
 			}
 		},
 		"node_modules/which-module": {
@@ -12645,6 +13636,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/workerpool": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
@@ -12803,6 +13801,13 @@
 			"engines": {
 				"node": ">=4.0"
 			}
+		},
+		"node_modules/xmlcreate": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",


### PR DESCRIPTION
Test coverage execution with istanbul fails in esbuild when using the
latest babel dependencies. Reverting the update to the last stable
versions.