### PR TITLE
deps: License- add exception for new deps

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -8,6 +8,9 @@
     "blueOak": "bronze"
   },
   "packages": {
+    "atomically": "2.0.3",
+		"stubborn-fs": "1.2.5",
+		"when-exit": "2.1.3",
     "@sapui5/types": "^1.120.4",
     "callsite": "1.0.0",
     "yesno": "0.4.0",


### PR DESCRIPTION
All three packages are licensed under the MIT license, but the package.json file is missing the license field.

PRs to add the license field have already been opened for all three packages.