### PR TITLE
ci(release-please): Remove prerelease configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,6 @@
 			"pull-request-header": ":tractor: New release prepared",
 			"pull-request-title-pattern": "release: v${version}",
 			"include-component-in-tag": false,
-			"bump-minor-pre-major": true,
-			"bump-patch-for-minor-pre-major": true,
-			"prerelease": true,
 			"changelog-sections": [
 				{
 					"type": "feat",


### PR DESCRIPTION
- remove boolean flag "prerelease" to no longer produce v0 releases
- remove no longer needed flags "bump-minor-pre-major" and "bump-patch-for-minor-pre-major"

JIRA: CPOUI5FOUNDATION-909
