### PR TITLE
feat: Support projects with type "module"

### DIFF
--- a/src/untyped.d.ts
+++ b/src/untyped.d.ts
@@ -3,18 +3,32 @@
 
 declare module "@ui5/project" {
 	type ProjectNamespace = string;
+
+	// Note: This is only a partial definition with required fields for type module
+	interface ProjectConfig {
+		resources: {
+			configuration: {
+				paths: Record<string, string>;
+			};
+		};
+	}
+
 	interface Project {
-		getNamespace: () => ProjectNamespace;
-		getReader: (options: import("@ui5/fs").ReaderOptions) => import("@ui5/fs").AbstractReader;
-		getRootReader: () => import("@ui5/fs").AbstractReader;
-		getRootPath: () => string;
-		getSourcePath: () => string;
-		_testPath: string; // TODO UI5 Tooling: Expose API for optional test path
+		getNamespace(): ProjectNamespace;
+		getReader(options: import("@ui5/fs").ReaderOptions): import("@ui5/fs").AbstractReader;
+		getRootReader(): import("@ui5/fs").AbstractReader;
+		getRootPath(): string;
+		getSourcePath(): string;
+		getType(): "application" | "library" | "module";
+
+		// TODO UI5 Tooling: Expose required information as API
+		_testPath: string;
 		_testPathExists: string;
 		_isSourceNamespaced: boolean;
+		_config: ProjectConfig; // Needed to read the paths configuration of projects with type module
 	}
 	interface ProjectGraph {
-		getRoot: () => Project;
+		getRoot(): Project;
 	}
 	interface DependencyTreeNode {
 		id: string;
@@ -70,13 +84,13 @@ declare module "@ui5/fs" {
 		contentModified: boolean;
 	}
 	interface Resource {
-		getBuffer: () => Promise<Buffer>;
-		getString: () => Promise<string>;
-		getStream: () => import("node:fs").ReadStream;
-		getName: () => string;
-		getPath: () => ResourcePath;
-		getProject: () => import("@ui5/project").Project;
-		getSourceMetadata: () => ResourceSourceMetadata;
+		getBuffer(): Promise<Buffer>;
+		getString(): Promise<string>;
+		getStream(): import("node:fs").ReadStream;
+		getName(): string;
+		getPath(): ResourcePath;
+		getProject(): import("@ui5/project").Project;
+		getSourceMetadata(): ResourceSourceMetadata;
 	}
 	type ReaderStyles = "buildtime" | "dist" | "runtime" | "flat";
 
@@ -89,11 +103,11 @@ declare module "@ui5/fs" {
 	type Filter = (resource: Resource) => boolean;
 
 	export interface AbstractReader {
-		byGlob: (virPattern: string | string[], options?: GlobOptions) => Promise<Resource[]>;
-		byPath: (path: string) => Promise<Resource>;
+		byGlob(virPattern: string | string[], options?: GlobOptions): Promise<Resource[]>;
+		byPath(path: string): Promise<Resource>;
 	}
 	export interface AbstractAdapter extends AbstractReader {
-		write: (resource: Resource) => Promise<void>;
+		write(resource: Resource): Promise<void>;
 	}
 }
 
@@ -133,13 +147,13 @@ declare module "@ui5/fs/resourceFactory" {
 
 declare module "@ui5/logger" {
 	interface Logger {
-		silly: (message: string) => void;
-		verbose: (message: string) => void;
-		perf: (message: string) => void;
-		info: (message: string) => void;
-		warn: (message: string) => void;
-		error: (message: string) => void;
-		isLevelEnabled: (level: string) => boolean;
+		silly(message: string): void;
+		verbose(message: string): void;
+		perf(message: string): void;
+		info(message: string): void;
+		warn(message: string): void;
+		error(message: string): void;
+		isLevelEnabled(level: string): boolean;
 	}
 
 	export function isLogLevelEnabled(logLevel: string): boolean;


### PR DESCRIPTION
This allows linting projects that currently do not fit any other project
structure of UI5 Tooling.

To lint such projects, a `ui5.yaml` needs to be added to the root of the
project with the following content:

```yaml
specVersion: "4.0"
type: module
metadata:
  name: <project-name>
resources:
  configuration:
    paths:
      /resources/<namespace>/: "<sources-folder>"
````

Placeholders `<project-name>`, `<namespace>` and `<sources-folder>` need
to be replaced with the actual values.

Example:
A project has its sources in a folder `src` and uses the namespace
`my.project`, so for example a source file named
`src/my/project/util/Formatter.js` would exist.
In this case the placeholders would be replaced as follows:
- `<project-name>`: `my.project`
- `<namespace>`: `my/project`
- `<sources-folder>`: `src`