### PR TITLE
fix: Match ignore-pattern starting with "./"

### DIFF
--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -314,6 +314,11 @@ function buildPatterns(patterns: string[]) {
 			pattern += "**/*";
 		}
 
+		// Remove leading "./" from the pattern, as it otherwise would not match
+		if (pattern.startsWith("./")) {
+			pattern = pattern.slice(2);
+		}
+
 		return new Minimatch(pattern, {flipNegate: true});
 	});
 }

--- a/test/lib/linter/linter.ts
+++ b/test/lib/linter/linter.ts
@@ -162,7 +162,7 @@ test.serial("lint: Ignore files from library.with.custom.paths", async (t) => {
 		ignorePatterns: [
 			"src/",
 			"!src/main/",
-			"ui5.yaml",
+			"./ui5.yaml", // Relative paths starting with "./" should match the same as without it
 		],
 	});
 


### PR DESCRIPTION
Providing an ignore pattern e.g. via CLI `--ignore-pattern` did not work
when the path started with "./".

Fixes: https://github.com/SAP/ui5-linter/issues/407