### PR TITLE
feat(linter): Extend project initialization fallbacks

### DIFF
--- a/test/fixtures/linter/projects/legacy-dirs/legacy.app.a/WebContent/manifest.json
+++ b/test/fixtures/linter/projects/legacy-dirs/legacy.app.a/WebContent/manifest.json
@@ -1,0 +1,7 @@
+{
+	"_version": "1.12.0",
+	"sap.app": {
+		"id": "com.app",
+		"type": "application"
+	}
+}

--- a/test/fixtures/linter/projects/legacy-dirs/legacy.app.b/src/main/webapp/manifest.json
+++ b/test/fixtures/linter/projects/legacy-dirs/legacy.app.b/src/main/webapp/manifest.json
@@ -1,0 +1,7 @@
+{
+	"_version": "1.12.0",
+	"sap.app": {
+		"id": "com.app",
+		"type": "application"
+	}
+}

--- a/test/fixtures/linter/projects/legacy-dirs/legacy.lib.a/src/main/jslib/.library
+++ b/test/fixtures/linter/projects/legacy-dirs/legacy.lib.a/src/main/jslib/.library
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<library xmlns="http://www.sap.com/sap.ui.library.xsd">
+	<name>library.with.custom.paths</name>
+	<vendor>SAP SE</vendor>
+	<version>${version}</version>
+	<copyright>${copyright}</copyright>
+</library>

--- a/test/fixtures/linter/projects/legacy-dirs/legacy.lib.b/src/main/uilib/.library
+++ b/test/fixtures/linter/projects/legacy-dirs/legacy.lib.b/src/main/uilib/.library
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<library xmlns="http://www.sap.com/sap.ui.library.xsd">
+	<name>library.with.custom.paths</name>
+	<vendor>SAP SE</vendor>
+	<version>${version}</version>
+	<copyright>${copyright}</copyright>
+</library>

--- a/test/fixtures/linter/projects/legacy-dirs/legacy.lib.c/src/main/js/.library
+++ b/test/fixtures/linter/projects/legacy-dirs/legacy.lib.c/src/main/js/.library
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<library xmlns="http://www.sap.com/sap.ui.library.xsd">
+	<name>library.with.custom.paths</name>
+	<vendor>SAP SE</vendor>
+	<version>${version}</version>
+	<copyright>${copyright}</copyright>
+</library>


### PR DESCRIPTION
Enhance compatibility for legacy UI5 projects that do not include a
ui5.yaml and do not use current best practice directory structures like
'webapp' for apps and 'src'/'test' for libraries.

In addition to those directories we now also check and eventually use
the following directories:

Applications:
* src/main/webapp
* WebContent

Libraries:
* src/main/jslib (+ src/test/jslib)
* src/main/uilib (+ src/test/uilib)
* src/main/js (+ src/test/js)