### PR TITLE
fix(ConfigManager): Resolve ESM import exception on Windows

### DIFF
--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -14,6 +14,9 @@ import {Minimatch} from "minimatch";
 export async function lintProject({
 	rootDir, filePatterns, ignorePatterns, coverage, details, configPath, ui5Config, noConfig,
 }: LinterOptions): Promise<LintResult[]> {
+	if (!path.isAbsolute(rootDir)) {
+		throw new Error(`rootDir must be an absolute path. Received: ${rootDir}`);
+	}
 	let config: UI5LintConfigType = {};
 	if (noConfig !== true) {
 		const configMngr = new ConfigManager(rootDir, configPath);

--- a/test/lib/linter/linter.ts
+++ b/test/lib/linter/linter.ts
@@ -424,3 +424,18 @@ test.serial("lint: getProjectGraph with different directory structures", async (
 		},
 	});
 });
+
+// Test project fixtures individually
+test.serial("lint: Relative rootDir path throws an exception", async (t) => {
+	const projectPath = path.join(fixturesProjectsPath, "com.ui5.troublesome.app");
+	const {lintProject} = t.context;
+
+	await t.throwsAsync(() => {
+		return lintProject({
+			rootDir: path.relative(__dirname, projectPath),
+			filePatterns: [],
+			coverage: true,
+			details: true,
+		});
+	});
+});

--- a/test/lib/utils/ConfigManager.ts
+++ b/test/lib/utils/ConfigManager.ts
@@ -9,7 +9,8 @@ const fixturesBasePath = path.join(__dirname, "..", "..", "fixtures", "linter");
 const fixturesProjectsPath = path.join(fixturesBasePath, "projects");
 
 test("Check config file", async (t) => {
-	const confManager = new ConfigManager("./test/fixtures/linter/projects/com.ui5.troublesome.app/",
+	const confManager = new ConfigManager(
+		path.join(fixturesProjectsPath, "com.ui5.troublesome.app"),
 		"ui5lint-custom.config.cjs");
 
 	const config = await confManager.getConfiguration();
@@ -24,7 +25,8 @@ test("Check config file", async (t) => {
 });
 
 test("Check config file auto discovery", async (t) => {
-	const confManager = new ConfigManager("./test/fixtures/linter/projects/com.ui5.troublesome.app/");
+	const confManager = new ConfigManager(
+		path.join(fixturesProjectsPath, "com.ui5.troublesome.app"));
 
 	const config = await confManager.getConfiguration();
 
@@ -48,7 +50,7 @@ test("Throws an error if config file has Syntax errors", async (t) => {
 
 test("Resolves to an empty config if default module is not found", async (t) => {
 	const confManager = new ConfigManager(
-		"./test/fixtures/linter/projects/library.with.custom.paths/");
+		path.join(fixturesProjectsPath, "library.with.custom.paths/"));
 
 	const config = await confManager.getConfiguration();
 


### PR DESCRIPTION
`import(path)` does not accept absolute Windows-paths since those seem to get confused with URLs.

Before, this was mitigated by always calculating a relative path (relative to the UI5 linter install directory). This however breaks on Windows if the target project is located on another drive as reported in https://github.com/SAP/ui5-linter/issues/458

Instead convert all paths to `file://`-URLs before passing them to `import()`.

Also, in linter.ts, enforce the project root path to always be absolute to simplify handling the path later on.

Resolves https://github.com/SAP/ui5-linter/issues/458
