### PR TITLE
deps(sax-wasm): Pin dependency to v2.2.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21,7 +21,7 @@
 				"he": "^1.2.0",
 				"json-source-map": "^0.6.1",
 				"minimatch": "^10.0.1",
-				"sax-wasm": "^2.2.4",
+				"sax-wasm": "2.2.4",
 				"typescript": "^5.7.2",
 				"update-notifier": "^7.3.1",
 				"yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"he": "^1.2.0",
 		"json-source-map": "^0.6.1",
 		"minimatch": "^10.0.1",
-		"sax-wasm": "^2.2.4",
+		"sax-wasm": "2.2.4",
 		"typescript": "^5.7.2",
 		"update-notifier": "^7.3.1",
 		"yargs": "^17.7.2"


### PR DESCRIPTION
Tests are failing with v2.3.2. It seems like events are emitted in a
different order now. Pinning to last working version for now to get
automatic updates working again for the repository.