### PR TITLE
build: Improve update-sapui5-types script

### DIFF
--- a/scripts/metadataProvider/helpers.ts
+++ b/scripts/metadataProvider/helpers.ts
@@ -12,7 +12,11 @@ const RAW_API_JSON_FILES_FOLDER = fileURLToPath(new URL(`../../tmp/apiJson`, imp
 export async function fetchAndExtractApiJsons(url: string) {
 	const response = await fetch(url);
 	if (!response.ok) {
-		throw new Error(`Unexpected response ${response.statusText}`);
+		if (response.status === 404) {
+			throw new Error(`The requested version does not exist`);
+		} else {
+			throw new Error(`Unexpected response ${response.status}: ${response.statusText}`);
+		}
 	}
 
 	if (response.body && response.body instanceof ReadableStream) {

--- a/scripts/update-sapui5-types.ts
+++ b/scripts/update-sapui5-types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import createMetadataInfo from "./metadataProvider/createMetadataInfo.js";
 import createPseudoModulesInfo from "./metadataProvider/createPseudoModulesInfo.js";
 import {cleanup, fetchAndExtractApiJsons} from "./metadataProvider/helpers.js";
@@ -28,6 +29,6 @@ try {
 	// Update @sapui5/types npm package
 	await execFile("npm", ["install", "-E", `@sapui5/types@${version}`]);
 } catch (err) {
-	process.stderr.write(String(err));
+	console.log(err);
 	process.exit(1);
 }


### PR DESCRIPTION
- Better handling of a missing version.

- Ensures that errors are logged to the console. `tsx` doesn't seem to
properly handle `process.stderr.write`, but `console.log` works fine.