### PR TITLE
fix(API): Remove ui5Config parameter defaulting

### DIFF
--- a/src/cli/base.ts
+++ b/src/cli/base.ts
@@ -101,7 +101,7 @@ const lintCommand: FixedCommandModule<object, LinterArg> = {
 				choices: ["stylish", "json", "markdown"],
 			})
 			.option("ui5-config", {
-				describe: "Set a custom path for the UI5 Config (default: './ui5.yaml')",
+				describe: "Set a custom path for the UI5 Config (default: './ui5.yaml' if that file exists)",
 				type: "string",
 			})
 			.coerce([

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export interface UI5LinterOptions {
 	coverage?: boolean;
 	/**
 	 * Path to a ui5.yaml file or an object representation of ui5.yaml
-	 * @default "./ui5.yaml"
+	 * @default "./ui5.yaml" (if that file exists)
 	 */
 	ui5Config?: string | object;
 	/**
@@ -53,7 +53,7 @@ export async function ui5lint(options?: UI5LinterOptions): Promise<LintResult[]>
 		config,
 		noConfig,
 		coverage = false,
-		ui5Config = "./ui5.yaml",
+		ui5Config,
 		rootDir = process.cwd(),
 	} = options ?? {};
 


### PR DESCRIPTION
Behavior should be identical to the linter CLI, where a fallback is done if no ui5.yaml can be found. This is only possible if no path is specified for the parameter, hence removing the defaulting in the API.