### PR TITLE
ci: Use @types/node based on minimum Node.js version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,7 +37,7 @@
 				"@istanbuljs/nyc-config-typescript": "^1.0.2",
 				"@stylistic/eslint-plugin": "^2.13.0",
 				"@types/he": "^1.2.3",
-				"@types/node": "^20.17.12",
+				"@types/node": "20.11.0",
 				"@types/sinon": "^17.0.3",
 				"@types/update-notifier": "^6.0.8",
 				"@types/yargs": "^17.0.33",
@@ -3703,12 +3703,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
-			"integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+			"version": "20.11.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+			"integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -12122,10 +12123,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-			"dev": true
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"@istanbuljs/nyc-config-typescript": "^1.0.2",
 		"@stylistic/eslint-plugin": "^2.13.0",
 		"@types/he": "^1.2.3",
-		"@types/node": "^20.17.12",
+		"@types/node": "20.11.0",
 		"@types/sinon": "^17.0.3",
 		"@types/update-notifier": "^6.0.8",
 		"@types/yargs": "^17.0.33",


### PR DESCRIPTION
This ensures that no new features are used that are not available in the minimum supported Node.js version.
