### PR TITLE
fix: Provide check for alternative names of the properties

### DIFF
--- a/src/linter/ui5Types/SourceFileLinter.ts
+++ b/src/linter/ui5Types/SourceFileLinter.ts
@@ -1247,7 +1247,7 @@ export default class SourceFileLinter {
 	 * from there. Directly finding the type of the property is not possible from here as it's
 	 * missing some context.
 	*/
-	#isPropertyBinding(node: ts.NewExpression | ts.CallExpression, propName: string[] | undefined) {
+	#isPropertyBinding(node: ts.NewExpression | ts.CallExpression, propName: string[]) {
 		const controlAmbientModule =
 			this.getSymbolModuleDeclaration(this.checker.getTypeAtLocation(node).symbol);
 

--- a/src/linter/ui5Types/SourceFileLinter.ts
+++ b/src/linter/ui5Types/SourceFileLinter.ts
@@ -1247,7 +1247,7 @@ export default class SourceFileLinter {
 	 * from there. Directly finding the type of the property is not possible from here as it's
 	 * missing some context.
 	*/
-	#isPropertyBinding(node: ts.NewExpression | ts.CallExpression, propName: string[]) {
+	#isPropertyBinding(node: ts.NewExpression | ts.CallExpression, propNames: string[]) {
 		const controlAmbientModule =
 			this.getSymbolModuleDeclaration(this.checker.getTypeAtLocation(node).symbol);
 
@@ -1260,7 +1260,7 @@ export default class SourceFileLinter {
 
 		const constructorArgType = classArg && this.checker.getTypeAtLocation(classArg.parameters[0]);
 		const argProperty = constructorArgType?.getProperties()
-			.find((p: ts.Symbol) => propName?.includes(p.name));
+			.find((p: ts.Symbol) => propNames.includes(p.name));
 		const argPropType = argProperty?.valueDeclaration &&
 			this.checker.getTypeAtLocation(argProperty.valueDeclaration);
 

--- a/src/linter/ui5Types/SourceFileLinter.ts
+++ b/src/linter/ui5Types/SourceFileLinter.ts
@@ -852,7 +852,7 @@ export default class SourceFileLinter {
 					this.isUi5ClassDeclaration(declaration, "sap/ui/core/Control")) &&
 					node.arguments[0] && ts.isObjectLiteralExpression(node.arguments[0])) {
 				// Setting names in UI5 are case sensitive. So, we're not sure of the exact name of the property.
-				// Check lowercase version of the property name as well.
+				// Check decapitalized version of the property name as well.
 				const propName = symbolName.replace("bind", "");
 				const alternativePropName = propName.charAt(0).toLowerCase() + propName.slice(1);
 


### PR DESCRIPTION
Resolves: https://github.com/SAP/ui5-linter/pull/499#discussion_r1930628950