### PR TITLE
fix: CodeQL scan

### DIFF
--- a/test/fixtures/linter/projects/com.ui5.troublesome.app/ui5lint-custom-broken.config.cjs
+++ b/test/fixtures/linter/projects/com.ui5.troublesome.app/ui5lint-custom-broken.config.cjs
@@ -1,4 +1,7 @@
-module.exports = {
-	ignores: [
+// CodeQL code scan complains about this file being broken.
+// This is a case we test for the config manager. So, wrapping it in a JSON.parse to avoid the error there,
+// but keep the test case valid.
+module.exports = JSON.parse(`{
+	"ignores": [
 		"test/**/*",
-		"!test/sap/m/visual/Wizard.spe
+		"!test/sap/m/visual/Wizard.spe`);


### PR DESCRIPTION
CodeQL code scan complains about this file being broken. This is a case we test for the config manager. So, wrapping it in a JSON.parse to avoid the error there, but keep the test case valid.