### PR TITLE
refactor: Use TypeScript LanguageService

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -10,10 +10,10 @@
 		"**/*.d.ts"
 	],
 	"check-coverage": true,
-	"statements": 87,
-	"branches": 79,
-	"functions": 94,
-	"lines": 87,
+	"statements": 89,
+	"branches": 82,
+	"functions": 95,
+	"lines": 89,
 	"watermarks": {
 		"statements": [70, 90],
 		"branches": [70, 90],

--- a/src/cli/base.ts
+++ b/src/cli/base.ts
@@ -1,5 +1,4 @@
 import {Argv, ArgumentsCamelCase, CommandModule, MiddlewareFunction} from "yargs";
-import {lintProject} from "../linter/linter.js";
 import {Text} from "../formatter/text.js";
 import {Json} from "../formatter/json.js";
 import {Markdown} from "../formatter/markdown.js";
@@ -10,6 +9,7 @@ import chalk from "chalk";
 import {isLogLevelEnabled} from "@ui5/logger";
 import ConsoleWriter from "@ui5/logger/writers/Console";
 import {getVersion} from "./version.js";
+import {ui5lint} from "../index.js";
 
 export interface LinterArg {
 	coverage: boolean;
@@ -152,13 +152,13 @@ async function handleLint(argv: ArgumentsCamelCase<LinterArg>) {
 
 	const reportCoverage = !!(process.env.UI5LINT_COVERAGE_REPORT ?? coverage);
 
-	const res = await lintProject({
+	const res = await ui5lint({
 		rootDir,
 		ignorePatterns,
 		filePatterns,
 		coverage: reportCoverage,
 		details,
-		configPath: config,
+		config,
 		ui5Config,
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {lintProject} from "./linter/linter.js";
 import type {LintResult} from "./linter/LinterContext.js";
+import SharedLanguageService from "./linter/ui5Types/SharedLanguageService.js";
 
 export type {LintResult} from "./linter/LinterContext.js";
 
@@ -66,5 +67,5 @@ export async function ui5lint(options?: UI5LinterOptions): Promise<LintResult[]>
 		configPath: config,
 		noConfig,
 		ui5Config,
-	});
+	}, new SharedLanguageService());
 }

--- a/src/linter/lintWorkspace.ts
+++ b/src/linter/lintWorkspace.ts
@@ -11,10 +11,12 @@ import LinterContext, {LintResult, LinterParameters, LinterOptions, FSToVirtualP
 import {createReader} from "@ui5/fs/resourceFactory";
 import {mergeIgnorePatterns, resolveReader} from "./linter.js";
 import {UI5LintConfigType} from "../utils/ConfigManager.js";
+import type SharedLanguageService from "./ui5Types/SharedLanguageService.js";
 
 export default async function lintWorkspace(
 	workspace: AbstractAdapter, filePathsWorkspace: AbstractAdapter,
-	options: LinterOptions & FSToVirtualPathOptions, config: UI5LintConfigType, patternsMatch: Set<string>
+	options: LinterOptions & FSToVirtualPathOptions, config: UI5LintConfigType, patternsMatch: Set<string>,
+	sharedLanguageService: SharedLanguageService
 ): Promise<LintResult[]> {
 	const done = taskStart("Linting Workspace");
 	const {relFsBasePath, virBasePath, relFsBasePathTest, virBasePathTest} = options;
@@ -55,7 +57,7 @@ export default async function lintWorkspace(
 		lintFileTypes(params),
 	]);
 
-	const typeLinter = new TypeLinter(params);
+	const typeLinter = new TypeLinter(params, sharedLanguageService);
 	await typeLinter.lint();
 	done();
 	return context.generateLintResults();

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -10,7 +10,7 @@ import {ProjectGraph} from "@ui5/project";
 import type {AbstractReader, Resource} from "@ui5/fs";
 import ConfigManager, {UI5LintConfigType} from "../utils/ConfigManager.js";
 import {Minimatch} from "minimatch";
-import SharedLanguageService from "./ui5Types/SharedLanguageService.js";
+import type SharedLanguageService from "./ui5Types/SharedLanguageService.js";
 
 export async function lintProject({
 	rootDir, filePatterns, ignorePatterns, coverage, details, configPath, ui5Config, noConfig,

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -90,7 +90,8 @@ export async function lintProject({
 
 export async function lintFile({
 	rootDir, filePatterns, ignorePatterns, namespace, coverage, details, configPath, noConfig,
-}: LinterOptions): Promise<LintResult[]> {
+}: LinterOptions, sharedLanguageService: SharedLanguageService
+): Promise<LintResult[]> {
 	let config: UI5LintConfigType = {};
 	if (noConfig !== true) {
 		const configMngr = new ConfigManager(rootDir, configPath);
@@ -102,9 +103,6 @@ export async function lintFile({
 		fsBasePath: rootDir,
 		virBasePath,
 	});
-
-	// TODO: Refactor lintFile
-	const sharedLanguageService = new SharedLanguageService();
 
 	const res = await lint(reader, {
 		rootDir,

--- a/src/linter/ui5Types/LanguageServiceHostProxy.ts
+++ b/src/linter/ui5Types/LanguageServiceHostProxy.ts
@@ -1,0 +1,82 @@
+import ts from "typescript";
+
+export default class LanguageServiceHostProxy implements ts.LanguageServiceHost {
+	private emptyLanguageServiceHost: ts.LanguageServiceHost;
+	private languageServiceHost: ts.LanguageServiceHost;
+
+	constructor() {
+		this.emptyLanguageServiceHost = this.languageServiceHost = new EmptyLanguageServiceHost();
+	}
+
+	setHost(languageServiceHostImpl: ts.LanguageServiceHost | null) {
+		this.languageServiceHost = languageServiceHostImpl ?? this.emptyLanguageServiceHost;
+	}
+
+	// ts.LanguageServiceHost implementation:
+
+	getCompilationSettings() {
+		return this.languageServiceHost.getCompilationSettings();
+	}
+
+	getScriptFileNames() {
+		return this.languageServiceHost.getScriptFileNames();
+	}
+
+	getScriptVersion(fileName: string) {
+		return this.languageServiceHost.getScriptVersion(fileName);
+	}
+
+	getScriptSnapshot(fileName: string) {
+		return this.languageServiceHost.getScriptSnapshot(fileName);
+	}
+
+	fileExists(filePath: string) {
+		return this.languageServiceHost.fileExists(filePath);
+	}
+
+	readFile(filePath: string) {
+		return this.languageServiceHost.readFile(filePath);
+	}
+
+	getDefaultLibFileName(options: ts.CompilerOptions) {
+		return this.languageServiceHost.getDefaultLibFileName(options);
+	}
+
+	getCurrentDirectory() {
+		return this.languageServiceHost.getCurrentDirectory();
+	}
+}
+
+class EmptyLanguageServiceHost implements ts.LanguageServiceHost {
+	getCompilationSettings() {
+		return {};
+	}
+
+	getScriptFileNames() {
+		return [];
+	}
+
+	getScriptVersion() {
+		return "";
+	}
+
+	getScriptSnapshot() {
+		return undefined;
+	}
+
+	fileExists() {
+		return false;
+	}
+
+	readFile() {
+		return "";
+	}
+
+	getCurrentDirectory() {
+		return "/";
+	}
+
+	getDefaultLibFileName(options: ts.CompilerOptions) {
+		return ts.getDefaultLibFileName(options);
+	}
+}

--- a/src/linter/ui5Types/LanguageServiceHostProxy.ts
+++ b/src/linter/ui5Types/LanguageServiceHostProxy.ts
@@ -57,7 +57,7 @@ class EmptyLanguageServiceHost implements ts.LanguageServiceHost {
 	}
 
 	getScriptVersion() {
-		return "";
+		return "0";
 	}
 
 	getScriptSnapshot() {
@@ -69,7 +69,7 @@ class EmptyLanguageServiceHost implements ts.LanguageServiceHost {
 	}
 
 	readFile() {
-		return "";
+		return undefined;
 	}
 
 	getCurrentDirectory() {

--- a/src/linter/ui5Types/LanguageServiceHostProxy.ts
+++ b/src/linter/ui5Types/LanguageServiceHostProxy.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 
 export default class LanguageServiceHostProxy implements ts.LanguageServiceHost {
-	private emptyLanguageServiceHost: ts.LanguageServiceHost;
+	private readonly emptyLanguageServiceHost: ts.LanguageServiceHost;
 	private languageServiceHost: ts.LanguageServiceHost;
 
 	constructor() {
@@ -47,7 +47,7 @@ export default class LanguageServiceHostProxy implements ts.LanguageServiceHost 
 	}
 }
 
-class EmptyLanguageServiceHost implements ts.LanguageServiceHost {
+export class EmptyLanguageServiceHost implements ts.LanguageServiceHost {
 	getCompilationSettings() {
 		return {};
 	}

--- a/src/linter/ui5Types/SharedLanguageService.ts
+++ b/src/linter/ui5Types/SharedLanguageService.ts
@@ -1,0 +1,46 @@
+import ts from "typescript";
+import LanguageServiceHostProxy from "./LanguageServiceHostProxy.js";
+
+export default class SharedLanguageService {
+	private readonly languageServiceHostProxy: LanguageServiceHostProxy;
+	private readonly languageService: ts.LanguageService;
+	private acquired = false;
+
+	constructor() {
+		this.languageServiceHostProxy = new LanguageServiceHostProxy();
+		this.languageService = ts.createLanguageService(this.languageServiceHostProxy, ts.createDocumentRegistry());
+	}
+
+	acquire(languageServiceHost: ts.LanguageServiceHost) {
+		if (this.acquired) {
+			throw new Error("SharedCompiler is already acquired");
+		}
+		this.acquired = true;
+
+		// Set actual LanguageServiceHost implementation
+		this.languageServiceHostProxy.setHost(languageServiceHost);
+	}
+
+	getProgram() {
+		if (!this.acquired) {
+			throw new Error("SharedCompiler is not acquired");
+		}
+
+		const program = this.languageService.getProgram();
+		if (!program) {
+			throw new Error("SharedCompiler failed to create a program");
+		}
+		return program;
+	}
+
+	release() {
+		if (!this.acquired) {
+			throw new Error("SharedCompiler is not acquired");
+		}
+
+		// Remove previously set LanguageServiceHost implementation
+		this.languageServiceHostProxy.setHost(null);
+
+		this.acquired = false;
+	}
+}

--- a/src/linter/ui5Types/SharedLanguageService.ts
+++ b/src/linter/ui5Types/SharedLanguageService.ts
@@ -5,6 +5,7 @@ export default class SharedLanguageService {
 	private readonly languageServiceHostProxy: LanguageServiceHostProxy;
 	private readonly languageService: ts.LanguageService;
 	private acquired = false;
+	private projectScriptVersion = 0;
 
 	constructor() {
 		this.languageServiceHostProxy = new LanguageServiceHostProxy();
@@ -42,5 +43,10 @@ export default class SharedLanguageService {
 		this.languageServiceHostProxy.setHost(null);
 
 		this.acquired = false;
+	}
+
+	getNextProjectScriptVersion() {
+		this.projectScriptVersion++;
+		return this.projectScriptVersion.toString();
 	}
 }

--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -104,7 +104,9 @@ export default class TypeChecker {
 			}
 		}
 
-		const host = await createVirtualLanguageServiceHost(this.#compilerOptions, files, sourceMaps, this.#context);
+		const projectScriptVersion = this.#sharedLanguageService.getNextProjectScriptVersion();
+
+		const host = await createVirtualLanguageServiceHost(this.#compilerOptions, files, sourceMaps, this.#context, projectScriptVersion);
 
 		this.#sharedLanguageService.acquire(host);
 

--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -106,7 +106,9 @@ export default class TypeChecker {
 
 		const projectScriptVersion = this.#sharedLanguageService.getNextProjectScriptVersion();
 
-		const host = await createVirtualLanguageServiceHost(this.#compilerOptions, files, sourceMaps, this.#context, projectScriptVersion);
+		const host = await createVirtualLanguageServiceHost(
+			this.#compilerOptions, files, sourceMaps, this.#context, projectScriptVersion
+		);
 
 		this.#sharedLanguageService.acquire(host);
 

--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -160,22 +160,15 @@ export default class TypeChecker {
 			// If requested, write out every resource that has a source map (which indicates it has been transformed)
 			// Loop over sourceMaps set
 			for (const [resourcePath, sourceMap] of sourceMaps) {
-				let fileContent = files.get(resourcePath);
-
-				if (typeof fileContent === "function") {
-					fileContent = fileContent();
-				}
+				const fileContent = files.get(resourcePath);
 				if (fileContent) {
 					await writeTransformedSources(process.env.UI5LINT_WRITE_TRANSFORMED_SOURCES,
 						resourcePath, fileContent, sourceMap);
 				}
 			}
 			// Although not being a typical transformed source, write out the byId dts file for debugging purposes
-			let byIdDts = files.get(CONTROLLER_BY_ID_DTS_PATH);
+			const byIdDts = files.get(CONTROLLER_BY_ID_DTS_PATH);
 			if (byIdDts) {
-				if (typeof byIdDts === "function") {
-					byIdDts = byIdDts();
-				}
 				await writeTransformedSources(process.env.UI5LINT_WRITE_TRANSFORMED_SOURCES,
 					CONTROLLER_BY_ID_DTS_PATH, byIdDts);
 			}

--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import {FileContents, createVirtualCompilerHost} from "./host.js";
+import {FileContents, createVirtualLanguageServiceHost} from "./host.js";
 import SourceFileLinter from "./SourceFileLinter.js";
 import {taskStart} from "../../utils/perf.js";
 import {getLogger} from "@ui5/logger";
@@ -9,6 +9,7 @@ import {AbstractAdapter} from "@ui5/fs";
 import {createAdapter, createResource} from "@ui5/fs/resourceFactory";
 import {loadApiExtract} from "../../utils/ApiExtract.js";
 import {CONTROLLER_BY_ID_DTS_PATH} from "../xmlTemplate/linter.js";
+import type SharedLanguageService from "./SharedLanguageService.js";
 
 const log = getLogger("linter:ui5Types:TypeLinter");
 
@@ -44,12 +45,17 @@ const DEFAULT_OPTIONS: ts.CompilerOptions = {
 };
 
 export default class TypeChecker {
+	#sharedLanguageService: SharedLanguageService;
 	#compilerOptions: ts.CompilerOptions;
 	#context: LinterContext;
 	#workspace: AbstractAdapter;
 	#filePathsWorkspace: AbstractAdapter;
 
-	constructor({workspace, filePathsWorkspace, context}: LinterParameters) {
+	constructor(
+		{workspace, filePathsWorkspace, context}: LinterParameters,
+		sharedLanguageService: SharedLanguageService
+	) {
+		this.#sharedLanguageService = sharedLanguageService;
 		this.#context = context;
 		this.#workspace = workspace;
 		this.#filePathsWorkspace = filePathsWorkspace;
@@ -98,11 +104,12 @@ export default class TypeChecker {
 			}
 		}
 
-		const host = await createVirtualCompilerHost(this.#compilerOptions, files, sourceMaps, this.#context);
+		const host = await createVirtualLanguageServiceHost(this.#compilerOptions, files, sourceMaps, this.#context);
+
+		this.#sharedLanguageService.acquire(host);
 
 		const createProgramDone = taskStart("ts.createProgram", undefined, true);
-		const program = ts.createProgram(
-			allResources.map((resource) => resource.getPath()), this.#compilerOptions, host);
+		const program = this.#sharedLanguageService.getProgram();
 		createProgramDone();
 
 		const getTypeCheckerDone = taskStart("program.getTypeChecker", undefined, true);
@@ -142,6 +149,8 @@ export default class TypeChecker {
 			}
 		}
 		typeCheckDone();
+
+		this.#sharedLanguageService.release();
 
 		if (process.env.UI5LINT_WRITE_TRANSFORMED_SOURCES) {
 			// If requested, write out every resource that has a source map (which indicates it has been transformed)

--- a/src/linter/ui5Types/host.ts
+++ b/src/linter/ui5Types/host.ts
@@ -6,6 +6,7 @@ import {createRequire} from "node:module";
 import transpileAmdToEsm from "./amdTranspiler/transpiler.js";
 import LinterContext, {ResourcePath} from "../LinterContext.js";
 import {getLogger} from "@ui5/logger";
+import {CONTROLLER_BY_ID_DTS_PATH} from "../xmlTemplate/linter.js";
 const log = getLogger("linter:ui5Types:host");
 const require = createRequire(import.meta.url);
 
@@ -189,8 +190,9 @@ export async function createVirtualLanguageServiceHost(
 			if (silly) {
 				log.silly(`getScriptVersion: ${fileName}`);
 			}
-			if (fileName.startsWith("/types/")) {
+			if (fileName.startsWith("/types/") && fileName !== CONTROLLER_BY_ID_DTS_PATH) {
 				// All types should be cached forever as they can be shared across projects
+				// except for the ControllerById.d.ts file which is generated per project
 				return "0";
 			}
 			// Currently we don't use incremental compilation within a project, so

--- a/test/lib/cli/base.ts
+++ b/test/lib/cli/base.ts
@@ -9,7 +9,7 @@ import type {LintResult} from "../../../src/linter/LinterContext.js";
 import type Base from "../../../src/cli/base.js";
 
 const test = anyTest as TestFn<{
-	lintProject: SinonStub;
+	ui5lint: SinonStub;
 	writeFile: SinonStub;
 	consoleLogStub: SinonStub;
 	processStdErrWriteStub: SinonStub;
@@ -42,7 +42,7 @@ test.beforeEach(async (t) => {
 	t.context.isLogLevelEnabledStub.withArgs("verbose").returns(false);
 	t.context.consoleWriterStopStub = sinon.stub();
 
-	t.context.lintProject = sinon.stub().resolves([lintResult]);
+	t.context.ui5lint = sinon.stub().resolves([lintResult]);
 	t.context.writeFile = sinon.stub().resolves();
 	t.context.cli = yargs();
 
@@ -51,8 +51,8 @@ test.beforeEach(async (t) => {
 	t.context.formatMarkdown = sinon.stub().returns("");
 
 	t.context.base = await esmock.p("../../../src/cli/base.js", {
-		"../../../src/linter/linter.js": {
-			lintProject: t.context.lintProject,
+		"../../../src/index.js": {
+			ui5lint: t.context.ui5lint,
 		},
 		"../../../src/formatter/coverage.js": {
 			Coverage: sinon.stub().callsFake(() => {
@@ -98,106 +98,106 @@ test.afterEach.always((t) => {
 });
 
 test.serial("ui5lint (default) ", async (t) => {
-	const {cli, lintProject, writeFile} = t.context;
+	const {cli, ui5lint, writeFile} = t.context;
 
 	await cli.parseAsync([]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
+	t.true(ui5lint.calledOnce, "Linter is called");
 	t.is(writeFile.callCount, 0, "Coverage was not called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
-		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, configPath: undefined,
+	t.deepEqual(ui5lint.getCall(0).args[0], {
+		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, config: undefined,
 		details: false, coverage: false, ui5Config: undefined,
 	});
 	t.is(t.context.consoleLogStub.callCount, 0, "console.log should not be used");
 });
 
 test.serial("ui5lint --coverage ", async (t) => {
-	const {cli, lintProject, writeFile} = t.context;
+	const {cli, ui5lint, writeFile} = t.context;
 
 	await cli.parseAsync(["--coverage"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
+	t.true(ui5lint.calledOnce, "Linter is called");
 	t.is(writeFile.callCount, 1, "Coverage was called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
-		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, configPath: undefined,
+	t.deepEqual(ui5lint.getCall(0).args[0], {
+		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, config: undefined,
 		details: false, coverage: true, ui5Config: undefined,
 	});
 	t.is(t.context.consoleLogStub.callCount, 0, "console.log should not be used");
 });
 
 test.serial("ui5lint --details ", async (t) => {
-	const {cli, lintProject, formatText} = t.context;
+	const {cli, ui5lint, formatText} = t.context;
 
 	await cli.parseAsync(["--details"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
+	t.true(ui5lint.calledOnce, "Linter is called");
 	t.true(formatText.getCall(0).args[1], "linter is called with 'details=true' flag");
 	t.is(t.context.consoleLogStub.callCount, 0, "console.log should not be used");
 });
 
 test.serial("ui5lint --format json ", async (t) => {
-	const {cli, lintProject, formatJson} = t.context;
+	const {cli, ui5lint, formatJson} = t.context;
 
 	await cli.parseAsync(["--format", "json"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
+	t.true(ui5lint.calledOnce, "Linter is called");
 	t.true(formatJson.calledOnce, "JSON formatter has been called");
 });
 
 test.serial("ui5lint --ignore-pattern ", async (t) => {
-	const {cli, lintProject} = t.context;
+	const {cli, ui5lint} = t.context;
 
 	await cli.parseAsync(["--ignore-pattern", "test/**/*"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
+	t.true(ui5lint.calledOnce, "Linter is called");
+	t.deepEqual(ui5lint.getCall(0).args[0], {
 		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: ["test/**/*"],
-		configPath: undefined, details: false, coverage: false, ui5Config: undefined,
+		config: undefined, details: false, coverage: false, ui5Config: undefined,
 	});
 });
 
 test.serial("ui5lint --format markdown", async (t) => {
-	const {cli, lintProject, formatMarkdown} = t.context;
+	const {cli, ui5lint, formatMarkdown} = t.context;
 
 	await cli.parseAsync(["--format", "markdown"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
+	t.true(ui5lint.calledOnce, "Linter is called");
 	t.true(formatMarkdown.calledOnce, "Markdown formatter has been called");
 });
 
 test.serial("ui5lint --config", async (t) => {
-	const {cli, lintProject} = t.context;
+	const {cli, ui5lint} = t.context;
 
 	await cli.parseAsync(["--config", "config.js"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
-		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, configPath: "config.js",
+	t.true(ui5lint.calledOnce, "Linter is called");
+	t.deepEqual(ui5lint.getCall(0).args[0], {
+		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, config: "config.js",
 		details: false, coverage: false, ui5Config: undefined,
 	});
 });
 
 test.serial("ui5lint --ui5-config", async (t) => {
-	const {cli, lintProject} = t.context;
+	const {cli, ui5lint} = t.context;
 
 	await cli.parseAsync(["--ui5-config", "ui5.yaml"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
-		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, configPath: undefined,
+	t.true(ui5lint.calledOnce, "Linter is called");
+	t.deepEqual(ui5lint.getCall(0).args[0], {
+		rootDir: path.join(process.cwd()), filePatterns: undefined, ignorePatterns: undefined, config: undefined,
 		details: false, coverage: false, ui5Config: "ui5.yaml",
 	});
 });
 
 test.serial("ui5lint path/to/file.js glob/**/*", async (t) => {
-	const {cli, lintProject} = t.context;
+	const {cli, ui5lint} = t.context;
 
 	await cli.parseAsync(["path/to/file.js", "glob/**/*"]);
 
-	t.true(lintProject.calledOnce, "Linter is called");
-	t.deepEqual(lintProject.getCall(0).args[0], {
+	t.true(ui5lint.calledOnce, "Linter is called");
+	t.deepEqual(ui5lint.getCall(0).args[0], {
 		rootDir: path.join(process.cwd()), filePatterns: ["path/to/file.js", "glob/**/*"],
-		ignorePatterns: undefined, configPath: undefined,
+		ignorePatterns: undefined, config: undefined,
 		details: false, coverage: false, ui5Config: undefined,
 	});
 });

--- a/test/lib/linter/_linterHelper.ts
+++ b/test/lib/linter/_linterHelper.ts
@@ -8,17 +8,20 @@ import SourceFileLinter from "../../../src/linter/ui5Types/SourceFileLinter.js";
 import {SourceFile, TypeChecker} from "typescript";
 import LinterContext, {LinterOptions, LintResult} from "../../../src/linter/LinterContext.js";
 import {ApiExtract} from "../../../src/utils/ApiExtract.js";
+import SharedLanguageService from "../../../src/linter/ui5Types/SharedLanguageService.js";
 
 util.inspect.defaultOptions.depth = 4; // Increase AVA's printing depth since coverageInfo objects are on level 4
 
 const test = anyTest as TestFn<{
 	sinon: sinonGlobal.SinonSandbox;
-	lintFile: SinonStub<[LinterOptions], Promise<LintResult[]>>;
+	lintFile: SinonStub<[LinterOptions, SharedLanguageService], Promise<LintResult[]>>;
+	sharedLanguageService: SharedLanguageService; // Has to be defined by the actual test
 }>;
 
 test.before(async (t) => {
 	const {lintModule: {lintFile}} = await esmockDeprecationText();
 	t.context.lintFile = lintFile;
+	t.context.sharedLanguageService = new SharedLanguageService();
 });
 
 // Mock getDeprecationText as we do not have control over the deprecated texts and they could
@@ -146,7 +149,7 @@ function testDefinition(
 			filePatterns: filePaths,
 			coverage: true,
 			details: true,
-		});
+		}, t.context.sharedLanguageService);
 		assertExpectedLintResults(t, res, fixturesPath,
 			filePaths.map((fileName) => namespace ? path.join("resources", namespace, fileName) : fileName));
 

--- a/test/lib/linter/linter.ts
+++ b/test/lib/linter/linter.ts
@@ -18,7 +18,7 @@ const fixturesProjectsPath = path.join(fixturesBasePath, "projects");
 const test = anyTest as TestFn<{
 	sinon: sinonGlobal.SinonSandbox;
 	lintProject: SinonStub<[LinterOptions, SharedLanguageService], Promise<LintResult[]>>;
-	sharedLanguageService: SharedLanguageService;
+	sharedLanguageService: SharedLanguageService; // Will be provided by _linterHelper
 }>;
 
 test.before(async (t) => {
@@ -26,8 +26,6 @@ test.before(async (t) => {
 
 	const {lintModule: {lintProject}} = await esmockDeprecationText();
 	t.context.lintProject = lintProject;
-
-	t.context.sharedLanguageService = new SharedLanguageService();
 });
 test.after.always((t) => {
 	t.context.sinon.restore();

--- a/test/lib/linter/ui5Types/LanguageServiceHostProxy.ts
+++ b/test/lib/linter/ui5Types/LanguageServiceHostProxy.ts
@@ -1,0 +1,34 @@
+import test from "ava";
+import LanguageServiceHostProxy from "../../../../src/linter/ui5Types/LanguageServiceHostProxy.js";
+
+test("LanguageServiceHostProxy default implementation - getCompilationSettings", (t) => {
+	t.deepEqual(new LanguageServiceHostProxy().getCompilationSettings(), {});
+});
+
+test("LanguageServiceHostProxy default implementation - getScriptFileNames", (t) => {
+	t.deepEqual(new LanguageServiceHostProxy().getScriptFileNames(), []);
+});
+
+test("LanguageServiceHostProxy default implementation - getScriptVersion", (t) => {
+	t.is(new LanguageServiceHostProxy().getScriptVersion("/foo"), "0");
+});
+
+test("LanguageServiceHostProxy default implementation - getScriptSnapshot", (t) => {
+	t.is(new LanguageServiceHostProxy().getScriptSnapshot("/foo"), undefined);
+});
+
+test("LanguageServiceHostProxy default implementation - fileExists", (t) => {
+	t.is(new LanguageServiceHostProxy().fileExists("/foo"), false);
+});
+
+test("LanguageServiceHostProxy default implementation - readFile", (t) => {
+	t.is(new LanguageServiceHostProxy().readFile("/foo"), undefined);
+});
+
+test("LanguageServiceHostProxy default implementation - getDefaultLibFileName", (t) => {
+	t.is(new LanguageServiceHostProxy().getDefaultLibFileName({}), "lib.d.ts");
+});
+
+test("LanguageServiceHostProxy default implementation - getCurrentDirectory", (t) => {
+	t.is(new LanguageServiceHostProxy().getCurrentDirectory(), "/");
+});

--- a/test/lib/linter/ui5Types/SharedLanguageService.ts
+++ b/test/lib/linter/ui5Types/SharedLanguageService.ts
@@ -1,0 +1,90 @@
+import test from "ava";
+import SharedLanguageService from "../../../../src/linter/ui5Types/SharedLanguageService.js";
+import {EmptyLanguageServiceHost} from "../../../../src/linter/ui5Types/LanguageServiceHostProxy.js";
+import ts from "typescript";
+
+test("SharedLanguageService - acquire and release", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+	const languageServiceHost = new EmptyLanguageServiceHost();
+
+	sharedLanguageService.acquire(languageServiceHost);
+	sharedLanguageService.release();
+
+	t.pass();
+});
+
+test("SharedLanguageService - acquire twice without release", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+	const languageServiceHost = new EmptyLanguageServiceHost();
+
+	sharedLanguageService.acquire(languageServiceHost);
+
+	t.throws(() => {
+		sharedLanguageService.acquire(languageServiceHost);
+	}, {
+		message: "SharedCompiler is already acquired",
+	});
+});
+
+test("SharedLanguageService - release without acquire", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+
+	t.throws(() => {
+		sharedLanguageService.release();
+	}, {
+		message: "SharedCompiler is not acquired",
+	});
+});
+
+test("SharedLanguageService - getProgram", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+	const languageServiceHost = new EmptyLanguageServiceHost();
+
+	sharedLanguageService.acquire(languageServiceHost);
+
+	const program = sharedLanguageService.getProgram();
+
+	t.truthy(program);
+});
+
+test("SharedLanguageService - getProgram fails", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+	const languageServiceHost = new EmptyLanguageServiceHost();
+
+	// This error can only be produced by setting a the internal language service
+	// to a syntactic language service which does not provide a program
+
+	/* @ts-expect-error languageService is defined as private readonly */
+	sharedLanguageService.languageService = ts.createLanguageService(
+		languageServiceHost, ts.createDocumentRegistry(),
+		ts.LanguageServiceMode.Syntactic
+	);
+
+	sharedLanguageService.acquire(languageServiceHost);
+
+	t.throws(() => {
+		sharedLanguageService.getProgram();
+	}, {
+		message: "SharedCompiler failed to create a program",
+	});
+});
+
+test("SharedLanguageService - getProgram without acquire", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+
+	t.throws(() => {
+		sharedLanguageService.getProgram();
+	}, {
+		message: "SharedCompiler is not acquired",
+	});
+});
+
+test("SharedLanguageService - getNextProjectScriptVersion", (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+	t.is(sharedLanguageService.getNextProjectScriptVersion(), "1");
+	t.is(sharedLanguageService.getNextProjectScriptVersion(), "2");
+	t.is(sharedLanguageService.getNextProjectScriptVersion(), "3");
+
+	// Count should be per instance
+	t.is(new SharedLanguageService().getNextProjectScriptVersion(), "1");
+});


### PR DESCRIPTION
Switching from just a `Program` to the `LanguageService` has several benefits:

- Adding/changing source files is possible without having to create a new program manually while keeping all unchanged files cached
- Host implementation is more lightweight
- A shared `LanguageService` can be used to improve performance when linting multiple independent files/projects within the same process/thread. This is currently only used internally by the tests, but a new public API can be easily provided.