### PR TITLE
refactor: Improve caching of shared type files

### DIFF
--- a/src/linter/ui5Types/host.ts
+++ b/src/linter/ui5Types/host.ts
@@ -6,7 +6,6 @@ import {createRequire} from "node:module";
 import transpileAmdToEsm from "./amdTranspiler/transpiler.js";
 import LinterContext, {ResourcePath} from "../LinterContext.js";
 import {getLogger} from "@ui5/logger";
-import {CONTROLLER_BY_ID_DTS_PATH} from "../xmlTemplate/linter.js";
 const log = getLogger("linter:ui5Types:host");
 const require = createRequire(import.meta.url);
 
@@ -136,6 +135,9 @@ export async function createVirtualLanguageServiceHost(
 		if (resourcePath.startsWith("/types/")) {
 			const fsPath = mapToTypePath(resourcePath);
 			if (fsPath) {
+				if (silly) {
+					log.silly(`Reading type file from fs: ${fsPath}`);
+				}
 				return ts.sys.readFile(fsPath);
 			}
 		}
@@ -163,11 +165,8 @@ export async function createVirtualLanguageServiceHost(
 			if (silly) {
 				log.silly(`getScriptVersion: ${fileName}`);
 			}
-			if (fileName.startsWith("/types/") && fileName !== CONTROLLER_BY_ID_DTS_PATH) {
-				// All types should be cached forever as they can be shared across projects
-				// except for the ControllerById.d.ts file which is generated per project
-				return "0";
-			}
+			// Note: The script version for the common files at /types/ is handled within the LanguageServiceHostProxy
+
 			// Currently we don't use incremental compilation within a project, so
 			// updating the script version is not necessary.
 			// However, as the language service is shared across multiple projects, we need


### PR DESCRIPTION
Caching the script snapshot instances further improves the performance
when re-using a shared service instance.