### PR TITLE
ci(test.yml): Use windows 2025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         version: [20, 22]
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-22.04, windows-2025, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
Runner for windows 2025 is released. Therefore migrating from `windows-2022` to `windows-2025`.