### PR TITLE
ci(test.yml): Use macos 15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         version: [20, 22]
-        os: [ubuntu-22.04, windows-2025, macos-14]
+        os: [ubuntu-22.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
Runner for macos 15 is released. Therefore migrating from `macos-14` to `macos-15`.