### PR TITLE
refactor: TypeLinter / SourceFileLinter

### DIFF
--- a/src/linter/ui5Types/SourceFileReporter.ts
+++ b/src/linter/ui5Types/SourceFileReporter.ts
@@ -30,11 +30,10 @@ export default class SourceFileReporter {
 	#coverageInfo: CoverageInfo[] = [];
 
 	constructor(
-		context: LinterContext, resourcePath: ResourcePath,
-		sourceFile: ts.SourceFile, sourceMap: string | undefined
+		context: LinterContext, sourceFile: ts.SourceFile, sourceMap: string | undefined
 	) {
 		this.#context = context;
-		this.#resourcePath = resourcePath;
+		this.#resourcePath = sourceFile.fileName;
 		this.#sourceFile = sourceFile;
 		if (sourceMap) {
 			const parsedSourceMap = JSON.parse(sourceMap) as EncodedSourceMap;
@@ -45,7 +44,7 @@ export default class SourceFileReporter {
 			}
 		}
 
-		this.#originalResourcePath = this.#getOriginalResourcePath() ?? resourcePath;
+		this.#originalResourcePath = this.#getOriginalResourcePath() ?? this.#resourcePath;
 		// Do not use messages from context yet, to allow local de-duplication
 		this.#coverageInfo = context.getCoverageInfo(this.#originalResourcePath);
 	}
@@ -119,7 +118,7 @@ export default class SourceFileReporter {
 		}
 	}
 
-	deduplicateMessages() {
+	addMessagesToContext() {
 		const lineColumnRawMessagesMap = new Map<string, RawLintMessage[]>();
 		const rawMessages: RawLintMessage[] = [];
 		if (this.#rawMessages.length === 0) {
@@ -160,5 +159,6 @@ export default class SourceFileReporter {
 		}
 
 		this.#context.addLintingMessages(this.#originalResourcePath, rawMessages);
+		this.#rawMessages = []; // Prevent messages from being added multiple times
 	}
 }

--- a/src/linter/ui5Types/asyncComponentFlags.ts
+++ b/src/linter/ui5Types/asyncComponentFlags.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import path from "node:path/posix";
-import SourceFileReporter from "./SourceFileReporter.js";
+import type SourceFileReporter from "./SourceFileReporter.js";
 import type {JSONSchemaForSAPUI5Namespace, SAPJSONSchemaForWebApplicationManifestFile} from "../../manifest.js";
 import LinterContext from "../LinterContext.js";
 import jsonMap from "json-source-map";

--- a/test/lib/linter/linter.ts
+++ b/test/lib/linter/linter.ts
@@ -5,7 +5,7 @@ import {fileURLToPath} from "node:url";
 import esmock from "esmock";
 import {
 	createTestsForFixtures, assertExpectedLintResults,
-	esmockDeprecationText, preprocessLintResultsForSnapshot,
+	createMockedLinterModules, preprocessLintResultsForSnapshot,
 } from "./_linterHelper.js";
 import {UI5LinterEngine} from "../../../src/index.js";
 
@@ -22,7 +22,7 @@ const test = anyTest as TestFn<{
 test.before(async (t) => {
 	t.context.sinon = sinonGlobal.createSandbox();
 
-	const {indexModule: {UI5LinterEngine}} = await esmockDeprecationText();
+	const {indexModule: {UI5LinterEngine}} = await createMockedLinterModules();
 	t.context.linterEngine = new UI5LinterEngine();
 });
 test.afterEach.always((t) => {


### PR DESCRIPTION
Create SourceFileReporter at a central place to ease adding message for
different files.

Reduced the number of arguments of the SourceFileLinter constructor
by passing the TypeLinter instance.

Adjusted the mocking of getDeprecationText in the tests to prevent
having to always align the SourceFileLinter constructor args in the tests.
