### PR TITLE
refactor: Update script version for autofixed file only

### DIFF
--- a/src/linter/lintWorkspace.ts
+++ b/src/linter/lintWorkspace.ts
@@ -44,6 +44,7 @@ export default async function lintWorkspace(
 				content,
 				messages: rawMessages,
 			});
+			// patternsMatch.add(filePath); // Eventually filter files that have been autofixed
 		}
 
 		log.verbose(`Autofixing ${autofixResources.size} files...`);
@@ -68,6 +69,7 @@ export default async function lintWorkspace(
 				});
 				await workspace.write(newResource);
 				await filePathsWorkspace.write(newResource);
+				sharedLanguageService.setScriptVersion(filePath, sharedLanguageService.getScriptVersion(filePath) + 1);
 			}
 
 			log.verbose("Linting again after applying fixes...");

--- a/src/linter/ui5Types/SharedLanguageService.ts
+++ b/src/linter/ui5Types/SharedLanguageService.ts
@@ -1,11 +1,15 @@
 import ts from "typescript";
 import LanguageServiceHostProxy from "./LanguageServiceHostProxy.js";
+import {getLogger} from "@ui5/logger";
+
+const log = getLogger("linter:SharedLanguageService");
 
 export default class SharedLanguageService {
 	private readonly languageServiceHostProxy: LanguageServiceHostProxy;
 	private readonly languageService: ts.LanguageService;
 	private acquired = false;
 	private projectScriptVersion = 0;
+	private fileScriptVersions = new Map<string, number>();
 
 	constructor() {
 		this.languageServiceHostProxy = new LanguageServiceHostProxy();
@@ -43,6 +47,16 @@ export default class SharedLanguageService {
 		this.languageServiceHostProxy.setHost(null);
 
 		this.acquired = false;
+	}
+
+	setScriptVersion(fileName: string, version: number) {
+		return this.fileScriptVersions.set(fileName, version);
+	}
+
+	getScriptVersion(fileName: string) {
+		const scriptVersion = this.fileScriptVersions.get(fileName) ?? this.projectScriptVersion;
+		log.silly(`getScriptVersion ${fileName} ${scriptVersion}`);
+		return scriptVersion;
 	}
 
 	getNextProjectScriptVersion() {

--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -109,10 +109,8 @@ export default class TypeLinter {
 			}
 		}
 
-		const projectScriptVersion = this.#sharedLanguageService.getNextProjectScriptVersion();
-
 		const host = await createVirtualLanguageServiceHost(
-			this.#compilerOptions, files, this.#sourceMaps, this.#context, projectScriptVersion
+			this.#compilerOptions, files, this.#sourceMaps, this.#context, this.#sharedLanguageService
 		);
 
 		this.#sharedLanguageService.acquire(host);

--- a/src/linter/ui5Types/host.ts
+++ b/src/linter/ui5Types/host.ts
@@ -6,6 +6,7 @@ import {createRequire} from "node:module";
 import transpileAmdToEsm from "./amdTranspiler/transpiler.js";
 import LinterContext, {ResourcePath} from "../LinterContext.js";
 import {getLogger} from "@ui5/logger";
+import type SharedLanguageService from "./SharedLanguageService.js";
 const log = getLogger("linter:ui5Types:host");
 const require = createRequire(import.meta.url);
 
@@ -72,7 +73,7 @@ export async function createVirtualLanguageServiceHost(
 	options: ts.CompilerOptions,
 	files: FileContents, sourceMaps: FileContents,
 	context: LinterContext,
-	projectScriptVersion: string
+	sharedLanguageService: SharedLanguageService
 ): Promise<ts.LanguageServiceHost> {
 	const silly = log.isLevelEnabled("silly");
 
@@ -177,7 +178,7 @@ export async function createVirtualLanguageServiceHost(
 			// However, as the language service is shared across multiple projects, we need
 			// to provide a version that is unique for each project to avoid impacting other
 			// projects that might use the same file path.
-			return projectScriptVersion;
+			return sharedLanguageService.getScriptVersion(fileName).toString();
 		},
 
 		getScriptSnapshot: (fileName) => {


### PR DESCRIPTION
This should be a potential improvement around the autofixer and improved LanguageService script version handling