### PR TITLE
ci: Increase test timeout / Don't fail fast on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Unit and Integration
     strategy:
+      fail-fast: false # Do not stop other jobs if one fails
       matrix:
         version: [20, 22, 23]
         os: [ubuntu-24.04, windows-2025, macos-15]

--- a/ava.config.js
+++ b/ava.config.js
@@ -18,4 +18,5 @@ export default {
 	},
 	nodeArguments,
 	workerThreads: false,
+	timeout: "20s", // Increased timeout for slower CI environments
 };


### PR DESCRIPTION
Sometimes the default timeout of 10s per test is not enough within
the GitHub Actions CI.
