### PR TITLE
ci(dependabot): Enable @sapui5/types updates again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,4 @@ updates:
     prefix: "deps"
     prefix-development: "build(deps-dev)"
   ignore:
-    - dependency-name: "@sapui5/types" # Updated manually via "npm run update-sapui5-types"
     - dependency-name: "@types/node" # Should be manually kept in sync with the minimum supported Node.js version

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,8 +18,14 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type)}}
+      - name: If @sapui5/types update, add notice to PR body
+        if: ${{contains(steps.metadata.outputs.dependency-names, '@sapui5/types')}}
+        run: gh pr edit "$PR_URL" --body "**NOTICE:** This PR informs about a new version of the @sapui5/types package, please manually execute the `npm run update-sapui5-types` script to update the types in the project and amend this commit."
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs (except @sapui5/types)
+        if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) && !contains(steps.metadata.outputs.dependency-names, '@sapui5/types'}}
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Depedabot will create PRs for new minor versions of @sapui5/types again,
however they will not be auto-merged. Instead, a notice is added to the
PR body, requesting a developer to execute the update script and amend
the commit before manually merging the update.