### PR TITLE
docs: Add usage example for format option and saving output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,18 @@ ui5lint --details
 
 #### `--format`
 
-Choose the output format. Currently, `stylish` (default), `json` and `markdown` are supported.
+Choose the output format. Currently, `stylish` (default), `json`, and `markdown` are supported.  
 
 **Example:**
 ```sh
 ui5lint --format json
+```
+
+To save the output to a file, use the `>` operator (works on macOS, Linux, and Windows):
+
+**Save to File:**
+```sh
+ui5lint --format markdown > ui5-linter-findings.md
 ```
 
 #### `--fix`


### PR DESCRIPTION
Just a suggestion to add to this to the README to save the output of the `format` option