### PR TITLE
ci: Replace reviewers config of dependabot by CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@SAP/ui5-foundation

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-  reviewers:
-  - "SAP/ui5-foundation"
   versioning-strategy: increase
   commit-message:
     prefix: "deps"


### PR DESCRIPTION
With https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/ GitHub announced the removal of the `reviewers` property end of May 2025. Therefore switching to the recommended `CODEOWNERS` file based setup.