### PR TITLE
test: Fix tests on Node v24, extend CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false # Do not stop other jobs if one fails
       matrix:
-        version: [20, 22, 23]
+        version: [20, 22, 23, 24]
         os: [ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/untyped.d.ts
+++ b/src/untyped.d.ts
@@ -157,3 +157,20 @@ declare module "@ui5/logger/writers/Console" {
 declare module "json-source-map" {
 	export function parse<T>(content: string): T;
 }
+
+declare module "fs" {
+	export interface Dirent {
+		/**
+		* The base path that this `fs.Dirent` object refers to.
+		* @since v20.12.0
+		*/
+		parentPath: string;
+
+		/**
+		* Alias for `dirent.parentPath`.
+		* @since v20.1.0
+		* @deprecated Since v20.12.0
+		*/
+		path: string;
+	}
+}

--- a/test/e2e/compare-ui5lint-fix-snapshots.ts
+++ b/test/e2e/compare-ui5lint-fix-snapshots.ts
@@ -17,7 +17,7 @@ test.serial("Compare 'ui5lint --fix' com.ui5.troublesome.app result snapshots", 
 		});
 
 	for (const file of projectFiles) {
-		const content = await readFile(path.join(file.path, file.name), {encoding: "utf-8"});
+		const content = await readFile(path.join(file.parentPath || file.path, file.name), {encoding: "utf-8"});
 		t.snapshot(`${file.name}:\n${content}`);
 	}
 });

--- a/test/lib/linter/_linterHelper.ts
+++ b/test/lib/linter/_linterHelper.ts
@@ -99,7 +99,7 @@ export function createTestsForFixtures(fixturesPath: string, fix = false) {
 		}).map((dirEntries) => {
 			return path.posix.join(
 				// Resolve relative path OS dependant, but do the join in POSIX format
-				path.relative(fixturesPath, dirEntries.path),
+				path.relative(fixturesPath, dirEntries.parentPath || dirEntries.path),
 				dirEntries.name
 			);
 		});
@@ -140,7 +140,7 @@ export function createTestsForFixtures(fixturesPath: string, fix = false) {
 	} catch (err) {
 		if (err instanceof Error) {
 			throw new Error(
-				`Failed to list files of directory ${fixturesPath}: ${err.message}`);
+				`Failed to list files of directory ${fixturesPath}: ${err.message}`, {cause: err});
 		}
 		throw err;
 	}


### PR DESCRIPTION
node:fs#Dirent.path has been deprecated in Node v20.12.0 and replaced by .parentPath which was added in the same v20.12.0 release: https://nodejs.org/docs/latest-v20.x/api/fs.html#direntparentpath

Node v24 has removed the deprecated dirent.path.

Since we still support Node v20.11.0, we need to check for one and fallback to the other depending on availability.
