### PR TITLE
refactor: Introduce Ui5TypeInfo

### DIFF
--- a/src/linter/LinterContext.ts
+++ b/src/linter/LinterContext.ts
@@ -5,6 +5,7 @@ import {LintMessageSeverity, MESSAGE, MESSAGE_INFO} from "./messages.js";
 import {MessageArgs} from "./MessageArgs.js";
 import ts from "typescript";
 import {FixHints} from "./ui5Types/fixHints/FixHints.js";
+import {Ui5TypeInfo} from "./ui5Types/utils/utils.js";
 
 export type FilePattern = string; // glob patterns
 export type FilePath = string; // Platform-dependent path
@@ -31,6 +32,7 @@ export interface RawLintMessage<M extends MESSAGE = MESSAGE> {
 	args: MessageArgs[M];
 	position?: PositionInfo;
 	fixHints?: FixHints;
+	ui5TypeInfo?: Ui5TypeInfo;
 }
 
 export interface LintMessage {

--- a/src/linter/ui5Types/SourceFileReporter.ts
+++ b/src/linter/ui5Types/SourceFileReporter.ts
@@ -12,6 +12,7 @@ import {MESSAGE} from "../messages.js";
 import {MessageArgs} from "../MessageArgs.js";
 import {getPositionsForNode} from "../../utils/nodePosition.js";
 import {FixHints} from "./fixHints/FixHints.js";
+import {Ui5TypeInfo} from "./utils/utils.js";
 
 interface ReporterCoverageInfo extends CoverageInfo {
 	node: ts.Node;
@@ -20,6 +21,7 @@ interface ReporterCoverageInfo extends CoverageInfo {
 interface SourceFileMessageOptions {
 	node?: ts.Node;
 	fixHints?: FixHints;
+	ui5TypeInfo?: Ui5TypeInfo;
 }
 
 export default class SourceFileReporter {
@@ -60,7 +62,7 @@ export default class SourceFileReporter {
 			line: 1,
 			column: 1,
 		};
-		const {node, fixHints} = options;
+		const {node, fixHints, ui5TypeInfo} = options;
 		if (node) {
 			const {start} = this.#getPositionsForNode(node);
 			// One-based to be aligned with most IDEs
@@ -72,7 +74,7 @@ export default class SourceFileReporter {
 
 		args ??= null as unknown as MessageArgs[M];
 
-		this.#rawMessages.push({id, args, position, fixHints});
+		this.#rawMessages.push({id, args, position, fixHints, ui5TypeInfo});
 	}
 
 	addCoverageInfo({node, message, messageDetails, category}: ReporterCoverageInfo) {

--- a/src/linter/ui5Types/utils/utils.ts
+++ b/src/linter/ui5Types/utils/utils.ts
@@ -346,3 +346,67 @@ export function extractSapUiNamespace(symbolName: string, moduleDeclaration: ts.
 		return namespace.join(".");
 	}
 }
+
+export enum Ui5TypeInfoKind {
+	Module,
+	Global,
+}
+
+export type Ui5TypeInfo = Ui5ModuleTypeInfo | Ui5GlobalTypeInfo;
+
+interface Ui5ModuleTypeInfo {
+	module: string; // module name (slash separated)
+	export: string; // complete export name with namespaces
+	basename?: string; // local name without namespaces
+	name?: string; // e.g. DataType name
+	kind: Ui5TypeInfoKind.Module;
+}
+
+interface Ui5GlobalTypeInfo {
+	namespace: string;
+	kind: Ui5TypeInfoKind.Global;
+}
+
+/**
+ * Extracts module / global type information from UI5 symbols.
+ */
+export function getUi5TypeInfoFromSymbol(symbol: ts.Symbol): Ui5TypeInfo | undefined {
+	let currentNode: ts.Node | undefined = symbol.valueDeclaration;
+	if (!currentNode) {
+		return undefined;
+	}
+	const name = symbol.name;
+	let module: string | undefined;
+	const namespace = [];
+	while (currentNode) {
+		if (ts.isModuleDeclaration(currentNode)) {
+			if (currentNode.flags & ts.NodeFlags.Namespace) {
+				namespace.unshift(currentNode.name.text);
+			} else if (currentNode.parent && ts.isSourceFile(currentNode.parent)) {
+				// Only consider top-level module declarations
+				module = currentNode.name.text;
+				break;
+			}
+		} else if (ts.isInterfaceDeclaration(currentNode) &&
+			currentNode.name.text === "JQuery"
+		) {
+			module = "jQuery";
+		}
+		currentNode = currentNode.parent;
+	}
+	if (module) {
+		const info: Ui5ModuleTypeInfo = {
+			kind: Ui5TypeInfoKind.Module,
+			module,
+			export: namespace.length ? (namespace.join(".") + "." + name) : name,
+			basename: name,
+		};
+		return info;
+	} else {
+		namespace.push(name);
+		return {
+			kind: Ui5TypeInfoKind.Global,
+			namespace: namespace.join("."),
+		};
+	}
+}


### PR DESCRIPTION
Introduces a Ui5TypeInfo which might be especially useful in future for
usage in the autofix context.

The info will be collected when checking for deprecations and attached
to the raw messages. For now, the information is only available
internally but exposing it via the linter messages might be done later
to allow consumers to use it.

JIRA: CPOUI5FOUNDATION-1073
