### PR TITLE
refactor(ui5Types/host): Improve isolated usage of host and add tests

### DIFF
--- a/src/linter/ui5Types/TypeLinter.ts
+++ b/src/linter/ui5Types/TypeLinter.ts
@@ -16,39 +16,6 @@ import {JSONSchemaForSAPUI5Namespace} from "../../manifest.js";
 
 const log = getLogger("linter:ui5Types:TypeLinter");
 
-const DEFAULT_OPTIONS: ts.CompilerOptions = {
-	target: ts.ScriptTarget.ES2022,
-	module: ts.ModuleKind.ES2022,
-	// Skip lib check to speed up linting. Libs should generally be fine,
-	// we might want to add a unit test doing the check during development
-	skipLibCheck: true,
-	// Include standard typescript libraries for ES2022 and DOM support
-	lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
-	// Disable lib replacement lookup as we don't rely on it
-	libReplacement: false,
-	// Allow and check JavaScript files since this is everything we'll do here
-	allowJs: true,
-	checkJs: false,
-	strict: true,
-	noImplicitAny: false,
-	strictNullChecks: false,
-	strictPropertyInitialization: false,
-	rootDir: "/",
-	// Library modules (e.g. sap/ui/core/library.js) do not have a default export but
-	// instead have named exports e.g. for enums defined in the module.
-	// However, in current JavaScript code (UI5 AMD) the whole object is exported, as there are no
-	// named exports outside of ES Modules / TypeScript.
-	// This property compensates this gap and tries to all usage of default imports where actually
-	// no default export is defined.
-	// NOTE: This setting should not be used when analyzing TypeScript code, as it would allow
-	// using an default import on library modules, which is not intended.
-	// A better solution:
-	// During transpilation, for every library module (where no default export exists),
-	// an "import * as ABC" instead of a default import is created.
-	// This logic needs to be in sync with the generator for UI5 TypeScript definitions.
-	allowSyntheticDefaultImports: true,
-};
-
 export default class TypeLinter {
 	#sharedLanguageService: SharedLanguageService;
 	#compilerOptions: ts.CompilerOptions;
@@ -69,7 +36,7 @@ export default class TypeLinter {
 		this.#workspace = workspace;
 		this.#filePathsWorkspace = filePathsWorkspace;
 		this.#libraryDependencies = libraryDependencies;
-		this.#compilerOptions = {...DEFAULT_OPTIONS};
+		this.#compilerOptions = {};
 
 		const namespace = context.getNamespace();
 		if (namespace) {

--- a/test/lib/linter/ui5Types/host.ts
+++ b/test/lib/linter/ui5Types/host.ts
@@ -1,0 +1,158 @@
+import test from "ava";
+import {createVirtualLanguageServiceHost} from "../../../../src/linter/ui5Types/host.js";
+import LinterContext from "../../../../src/linter/LinterContext.js";
+import SharedLanguageService from "../../../../src/linter/ui5Types/SharedLanguageService.js";
+
+// List of TypeScript library files that are loaded by default in the virtual language service host.
+const LIB_TYPE_FILES = [
+	"/types/typescript/lib/lib.es5.d.ts",
+	"/types/typescript/lib/lib.es2015.d.ts",
+	"/types/typescript/lib/lib.es2016.d.ts",
+	"/types/typescript/lib/lib.es2017.d.ts",
+	"/types/typescript/lib/lib.es2018.d.ts",
+	"/types/typescript/lib/lib.es2019.d.ts",
+	"/types/typescript/lib/lib.es2020.d.ts",
+	"/types/typescript/lib/lib.es2021.d.ts",
+	"/types/typescript/lib/lib.es2022.d.ts",
+	"/types/typescript/lib/lib.dom.d.ts",
+	"/types/typescript/lib/lib.es2015.core.d.ts",
+	"/types/typescript/lib/lib.es2015.collection.d.ts",
+	"/types/typescript/lib/lib.es2015.generator.d.ts",
+	"/types/typescript/lib/lib.es2015.iterable.d.ts",
+	"/types/typescript/lib/lib.es2015.promise.d.ts",
+	"/types/typescript/lib/lib.es2015.proxy.d.ts",
+	"/types/typescript/lib/lib.es2015.reflect.d.ts",
+	"/types/typescript/lib/lib.es2015.symbol.d.ts",
+	"/types/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+	"/types/typescript/lib/lib.es2016.array.include.d.ts",
+	"/types/typescript/lib/lib.es2016.intl.d.ts",
+	"/types/typescript/lib/lib.es2017.arraybuffer.d.ts",
+	"/types/typescript/lib/lib.es2017.date.d.ts",
+	"/types/typescript/lib/lib.es2017.object.d.ts",
+	"/types/typescript/lib/lib.es2017.sharedmemory.d.ts",
+	"/types/typescript/lib/lib.es2017.string.d.ts",
+	"/types/typescript/lib/lib.es2017.intl.d.ts",
+	"/types/typescript/lib/lib.es2017.typedarrays.d.ts",
+	"/types/typescript/lib/lib.es2018.asyncgenerator.d.ts",
+	"/types/typescript/lib/lib.es2018.asynciterable.d.ts",
+	"/types/typescript/lib/lib.es2018.intl.d.ts",
+	"/types/typescript/lib/lib.es2018.promise.d.ts",
+	"/types/typescript/lib/lib.es2018.regexp.d.ts",
+	"/types/typescript/lib/lib.es2019.array.d.ts",
+	"/types/typescript/lib/lib.es2019.object.d.ts",
+	"/types/typescript/lib/lib.es2019.string.d.ts",
+	"/types/typescript/lib/lib.es2019.symbol.d.ts",
+	"/types/typescript/lib/lib.es2019.intl.d.ts",
+	"/types/typescript/lib/lib.es2020.bigint.d.ts",
+	"/types/typescript/lib/lib.es2020.date.d.ts",
+	"/types/typescript/lib/lib.es2020.promise.d.ts",
+	"/types/typescript/lib/lib.es2020.sharedmemory.d.ts",
+	"/types/typescript/lib/lib.es2020.string.d.ts",
+	"/types/typescript/lib/lib.es2020.symbol.wellknown.d.ts",
+	"/types/typescript/lib/lib.es2020.intl.d.ts",
+	"/types/typescript/lib/lib.es2020.number.d.ts",
+	"/types/typescript/lib/lib.es2021.promise.d.ts",
+	"/types/typescript/lib/lib.es2021.string.d.ts",
+	"/types/typescript/lib/lib.es2021.weakref.d.ts",
+	"/types/typescript/lib/lib.es2021.intl.d.ts",
+	"/types/typescript/lib/lib.es2022.array.d.ts",
+	"/types/typescript/lib/lib.es2022.error.d.ts",
+	"/types/typescript/lib/lib.es2022.intl.d.ts",
+	"/types/typescript/lib/lib.es2022.object.d.ts",
+	"/types/typescript/lib/lib.es2022.string.d.ts",
+	"/types/typescript/lib/lib.es2022.regexp.d.ts",
+	"/types/typescript/lib/lib.decorators.d.ts",
+	"/types/typescript/lib/lib.decorators.legacy.d.ts",
+];
+
+test("createVirtualLanguageServiceHost: Empty project", async (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+
+	const fileContents = new Map<string, string>([
+		["/resources/test/test.js", ""],
+	]);
+	const sourceMaps = new Map<string, string>();
+	const context = new LinterContext({
+		rootDir: "/",
+		namespace: "test",
+	});
+	const projectScriptVersion = sharedLanguageService.getNextProjectScriptVersion();
+
+	const host = await createVirtualLanguageServiceHost(
+		{}, fileContents, sourceMaps, context, projectScriptVersion, undefined
+	);
+
+	sharedLanguageService.acquire(host);
+
+	const program = sharedLanguageService.getProgram();
+
+	// Check for the minimum loaded files. This needs to be adjusted when the default compiler options
+	// are changed or additional type definitions are added.
+	const sourceFileNames = program.getSourceFiles().map((sf) => sf.fileName);
+	t.deepEqual(sourceFileNames, [
+		...LIB_TYPE_FILES,
+		"/resources/test/test.js",
+		"/types/@types/jquery/JQueryStatic.d.ts",
+		"/types/@types/jquery/JQuery.d.ts",
+		"/types/@types/jquery/misc.d.ts",
+		"/types/@types/jquery/legacy.d.ts",
+		"/types/@types/jquery/index.d.ts",
+		"/types/@types/qunit/index.d.ts",
+		"/types/@types/sizzle/index.d.ts",
+		"/types/@ui5/linter/types/jquery.sap.mobile.d.ts",
+		"/types/@ui5/linter/types/jquery.sap.d.ts",
+		"/types/@ui5/linter/types/index.d.ts",
+		"/types/@sapui5/types/types/sap.ui.core.d.ts",
+		"/types/@ui5/linter/types/pseudo-modules/sap.ui.core.d.ts",
+		"/types/@ui5/linter/types/sapui5/sap.ui.core.d.ts",
+	]);
+});
+
+test("createVirtualLanguageServiceHost: Minimal project with sap/m/Button import", async (t) => {
+	const sharedLanguageService = new SharedLanguageService();
+
+	const fileContents = new Map<string, string>([
+		["/resources/test/test.js", "sap.ui.define(['sap/m/Button'], function() {});"],
+	]);
+	const sourceMaps = new Map<string, string>();
+	const context = new LinterContext({
+		rootDir: "/",
+		namespace: "test",
+	});
+	const projectScriptVersion = sharedLanguageService.getNextProjectScriptVersion();
+
+	const host = await createVirtualLanguageServiceHost(
+		{}, fileContents, sourceMaps, context, projectScriptVersion, undefined
+	);
+
+	sharedLanguageService.acquire(host);
+
+	const program = sharedLanguageService.getProgram();
+
+	// Check for the minimum loaded files. This needs to be adjusted when the default compiler options
+	// are changed or additional type definitions are added.
+	const sourceFileNames = program.getSourceFiles().map((sf) => sf.fileName);
+	t.deepEqual(sourceFileNames, [
+		...LIB_TYPE_FILES,
+		"/types/@sapui5/types/types/sap.ui.core.d.ts",
+		"/types/@ui5/linter/types/pseudo-modules/sap.ui.core.d.ts",
+		"/types/@ui5/linter/types/sapui5/sap.ui.core.d.ts",
+		"/types/@sapui5/types/types/sap.ui.unified.d.ts",
+		"/types/@ui5/linter/types/pseudo-modules/sap.ui.unified.d.ts",
+		"/types/@ui5/linter/types/sapui5/sap.ui.unified.d.ts",
+		"/types/@sapui5/types/types/sap.m.d.ts",
+		"/types/@ui5/linter/types/pseudo-modules/sap.m.d.ts",
+		"/types/@ui5/linter/types/sapui5/sap.m.d.ts",
+		"/resources/test/test.js",
+		"/types/@types/jquery/JQueryStatic.d.ts",
+		"/types/@types/jquery/JQuery.d.ts",
+		"/types/@types/jquery/misc.d.ts",
+		"/types/@types/jquery/legacy.d.ts",
+		"/types/@types/jquery/index.d.ts",
+		"/types/@types/qunit/index.d.ts",
+		"/types/@types/sizzle/index.d.ts",
+		"/types/@ui5/linter/types/jquery.sap.mobile.d.ts",
+		"/types/@ui5/linter/types/jquery.sap.d.ts",
+		"/types/@ui5/linter/types/index.d.ts",
+	]);
+});


### PR DESCRIPTION
This allows to create a host with the right compiler options which is
helpful to write unit tests for TypeScript AST functionality without
having to run the full linter.
