### PR TITLE
test: Add test for nested MO-properties containing a 'type' field

### DIFF
--- a/test/fixtures/linter/rules/NoDeprecatedApi/NoDeprecatedApi.js
+++ b/test/fixtures/linter/rules/NoDeprecatedApi/NoDeprecatedApi.js
@@ -1,9 +1,16 @@
 sap.ui.define([
 	"sap/m/Button", "sap/m/DateTimeInput", "sap/base/util/includes", "sap/ui/Device", "sap/ui/core/library", "sap/ui/generic/app/navigation/service/NavigationHandler",
-	"sap/ui/table/Table", "sap/ui/table/plugins/MultiSelectionPlugin", "sap/ui/core/Configuration", "sap/m/library"
-], function(Button, DateTimeInput, includes, Device, coreLib, NavigationHandler, Table, MultiSelectionPlugin, Configuration, mobileLib) {
+	"sap/ui/table/Table", "sap/ui/table/plugins/MultiSelectionPlugin", "sap/ui/core/Configuration", "sap/m/library",
+	"sap/gantt/config/Shape",
+], function(Button, DateTimeInput, includes, Device, coreLib, NavigationHandler, Table, MultiSelectionPlugin, Configuration, mobileLib, Shape) {
 	"use strict";
 	var dateTimeInput = new DateTimeInput(); // Control is deprecated. A finding only appears for the module dependency, not for the usage.
+
+	var shape = new Shape({
+		shapeProperties: {
+			type: "{some_type}",
+		}
+	});
 
 	var btn = new Button({
 		blocked: true, // Property "blocked" is deprecated


### PR DESCRIPTION
This is currently incorrectly detected as a global variable `{some_type}`

Possibly related to the discussion at
https://github.com/SAP/ui5-linter/pull/480#discussion_r1925184845

I found this in our internal smoke tests. It only came up as a new finding after the recent refactoring.