### PR TITLE
ci(GHA): Downgrade Windows image to 2022

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # Do not stop other jobs if one fails
       matrix:
         version: [20, 22, 24]
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-24.04, windows-2022, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
This might resolve occasional test failures reported in https://github.com/UI5/linter/issues/709
    
These might be related to the Windows 2025 image. Note that GitHub actions still tags Windows 2022 as 'latest', so it should be safe to revert to that: https://github.com/actions/runner-images?tab=readme-ov-file#available-images