### PR TITLE
ci(release-please): Migrate to googleapis/release-please-action@v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}
     steps:
-    - uses: google-github-actions/release-please-action@v4
+    - uses: googleapis/release-please-action@v4
       id: release
       with:
         token: ${{secrets.GH_OPENUI5BOT}}


### PR DESCRIPTION
`google-github-actions/release-please-action@v4` is deprecated. Therefore use `googleapis/release-please-action@v4`