### PR TITLE
deps: Bump tar from 7.5.6 to 7.5.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18125,9 +18125,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-			"integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -127,13 +127,13 @@
 	},
 	"overrides": {
 		"pacote@<=20": {
-			"tar": "^7.5.6"
+			"tar": "^7.5.7"
 		},
 		"cacache@18": {
-			"tar": "^7.5.6"
+			"tar": "^7.5.7"
 		},
 		"node-gyp@10": {
-			"tar": "^7.5.6"
+			"tar": "^7.5.7"
 		},
 		"@ui5-language-assistant/semantic-model@^3.3.1": {
 			"lodash": "^4.17.23"


### PR DESCRIPTION
Resolves alerts for https://github.com/advisories/GHSA-34x7-hfp2-rc4v

As per our assessment this vulnerability is not exploitable in the context of UI5 linter.