### PR TITLE
ci: Use GitHub environment for publishing workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write # Required for trusted publishing via OIDC (https://docs.npmjs.com/trusted-publishers)
+    # The GitHub Actions Environment configured for the trusted publisher
+    environment: npmjs:@ui5/linter
     steps:
     - name: Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
Once merged, we need to change the corresponding Trusted Publisher setting on npm side to use this environment

JIRA: CPOUI5FOUNDATION-1239
