### PR TITLE
ci: Harden workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   pull-request:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}


### PR DESCRIPTION
- Scope release-please write permissions to the pull-request job so the
  publish-package job runs with only id-token: write.
- Replace spoofable github.actor check in dependabot-auto-merge with
  github.event.pull_request.user.login. Note: spoofing the dependabot
  actor alone is not sufficient to trigger the auto-merge step. The
  dependabot/fetch-metadata action only emits outputs for genuine
  dependabot PRs, so the merge step's check on
  steps.metadata.outputs.update-type would no-op on a spoofed run. The
  change closes the gap defensively.
