### PR TITLE
ci: Add aggregator job for test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,18 @@ jobs:
 
     - name: Run unit tests
       run: npm run unit
+
+  # Aggregator so branch protection can require a single "Tests" check
+  # instead of every matrix combination.
+  tests:
+    name: Tests
+    needs: test
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check matrix result
+      run: |
+        if [ "${{ needs.test.result }}" != "success" ]; then
+          echo "Test matrix result: ${{ needs.test.result }}"
+          exit 1
+        fi


### PR DESCRIPTION
Add a 'Tests' job that depends on the full test matrix so branch
protection can require a single check instead of every Node/OS
combination. The matrix rows remain visible in the PR checks list;
only the required-check surface collapses.

'if: always()' ensures the aggregator still runs when matrix cells fail,
so a failure surfaces as 'failed' rather than 'skipped'.
